### PR TITLE
Try to identify remote users by their token

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -41,9 +41,6 @@ use OCA\Activity\ViewInfoCache;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\IContainer;
-use OCP\IUser;
-use OCP\Share;
-use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Util;
 
 class Application extends App {
@@ -175,28 +172,9 @@ class Application extends App {
 		 * Core Services
 		 */
 		$container->registerService('CurrentUID', function(IContainer $c) {
-			/** @var \OC\Server $server */
-			$server = $c->query('ServerContainer');
-
-			$user = $server->getUserSession()->getUser();
-			if ($user instanceof IUser) {
-				return (string) $user->getUID();
-			}
-
-			$request = $server->getRequest();
-			if (!empty($request->server['PHP_AUTH_USER'])) {
-				$token = $request->server['PHP_AUTH_USER'];
-				try {
-					$share = $server->getShareManager()->getShareByToken($token);
-					if ($share->getShareType() === Share::SHARE_TYPE_REMOTE) {
-						return $share->getSharedWith();
-					}
-				} catch (ShareNotFound $e) {
-					// No share, use the fallback
-				}
-			}
-
-			return '';
+			/** @var \OCA\Activity\CurrentUser $currentUser */
+			$currentUser = $c->query('OCA\Activity\CurrentUser');
+			return $currentUser->getUserIdentifier();
 		});
 
 		/**

--- a/lib/CurrentUser.php
+++ b/lib/CurrentUser.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Activity;
+
+
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Share;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+
+class CurrentUser {
+
+	/** @var IUserSession */
+	protected $userSession;
+	/** @var IRequest */
+	protected $request;
+	/** @var IManager */
+	protected $shareManager;
+
+	/** @var string */
+	protected $identifier;
+
+	/**
+	 * @param IUserSession $userSession
+	 * @param IRequest $request
+	 * @param IManager $shareManager
+	 */
+	public function __construct(IUserSession $userSession, IRequest $request, IManager $shareManager) {
+		$this->userSession = $userSession;
+		$this->request = $request;
+		$this->shareManager = $shareManager;
+	}
+
+	/**
+	 * Get an identifier for the user, session or token
+	 * @return string
+	 */
+	public function getUserIdentifier() {
+		if ($this->identifier === null) {
+			$this->identifier = $this->getUID();
+
+			if ($this->identifier === null) {
+				$this->identifier = $this->getCloudIDFromToken();
+
+				if ($this->identifier === null) {
+					// Nothing worked, fallback to empty string
+					$this->identifier = '';
+				}
+			}
+		}
+
+		return $this->identifier;
+	}
+
+	/**
+	 * Get the current user from the session
+	 * @return string|null
+	 */
+	public function getUID() {
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser) {
+			return (string) $user->getUID();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the cloud ID from the sharing token
+	 * @return string|null
+	 */
+	protected function getCloudIDFromToken() {
+		if (!empty($this->request->server['PHP_AUTH_USER'])) {
+			$token = $this->request->server['PHP_AUTH_USER'];
+			try {
+				$share = $this->shareManager->getShareByToken($token);
+				if ($share->getShareType() === Share::SHARE_TYPE_REMOTE) {
+					return $share->getSharedWith();
+				}
+			} catch (ShareNotFound $e) {
+				// No share, use the fallback
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Formatter/FileFormatter.php
+++ b/lib/Formatter/FileFormatter.php
@@ -42,13 +42,18 @@ class FileFormatter implements IFormatter {
 	 * @param ViewInfoCache $infoCache
 	 * @param IURLGenerator $urlGenerator
 	 * @param IL10N $l
-	 * @param string $user
 	 */
-	public function __construct(ViewInfoCache $infoCache, IURLGenerator $urlGenerator, IL10N $l, $user) {
+	public function __construct(ViewInfoCache $infoCache, IURLGenerator $urlGenerator, IL10N $l) {
 		$this->infoCache = $infoCache;
 		$this->urlGenerator = $urlGenerator;
 		$this->l = $l;
-		$this->user = $user;
+	}
+
+	/**
+	 * @param string $user
+	 */
+	public function setUser($user) {
+		$this->user = (string) $user;
 	}
 
 	/**

--- a/lib/Formatter/UserFormatter.php
+++ b/lib/Formatter/UserFormatter.php
@@ -23,7 +23,6 @@
 namespace OCA\Activity\Formatter;
 
 use OCP\Activity\IEvent;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -42,10 +41,10 @@ class UserFormatter implements IFormatter {
 
 	/**
 	 * @param IUserManager $userManager
-	 * @param IL10N $l
 	 * @param CloudIDFormatter $cloudIDFormatter
+	 * @param IL10N $l
 	 */
-	public function __construct(IUserManager $userManager, IL10N $l, CloudIDFormatter $cloudIDFormatter) {
+	public function __construct(IUserManager $userManager, CloudIDFormatter $cloudIDFormatter, IL10N $l) {
 		$this->manager = $userManager;
 		$this->l = $l;
 		$this->cloudIDFormatter = $cloudIDFormatter;

--- a/lib/Formatter/UserFormatter.php
+++ b/lib/Formatter/UserFormatter.php
@@ -25,22 +25,30 @@ namespace OCA\Activity\Formatter;
 use OCP\Activity\IEvent;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Util;
 
 class UserFormatter implements IFormatter {
+
 	/** @var IUserManager */
 	protected $manager;
+
 	/** @var IL10N */
 	protected $l;
+
+	/** @var CloudIDFormatter */
+	protected $cloudIDFormatter;
 
 	/**
 	 * @param IUserManager $userManager
 	 * @param IL10N $l
+	 * @param CloudIDFormatter $cloudIDFormatter
 	 */
-	public function __construct(IUserManager $userManager, IL10N $l) {
+	public function __construct(IUserManager $userManager, IL10N $l, CloudIDFormatter $cloudIDFormatter) {
 		$this->manager = $userManager;
 		$this->l = $l;
+		$this->cloudIDFormatter = $cloudIDFormatter;
 	}
 
 	/**
@@ -56,9 +64,27 @@ class UserFormatter implements IFormatter {
 		}
 
 		$user = $this->manager->get($parameter);
-		$displayName = ($user) ? $user->getDisplayName() : $parameter;
+		if (!($user instanceof IUser)) {
+			if ($this->isRemoteUser($parameter)) {
+				// Remote user detected
+				return $this->cloudIDFormatter->format($event, $parameter);
+			}
+			$displayName = $parameter;
+		} else {
+			$displayName = $user->getDisplayName();
+		}
 		$parameter = Util::sanitizeHTML($parameter);
 
 		return '<user display-name="' . Util::sanitizeHTML($displayName) . '">' . Util::sanitizeHTML($parameter) . '</user>';
+	}
+
+	/**
+	 * Very simple "remote user" detection should be improved someday™
+	 *
+	 * @param string $parameter
+	 * @return bool
+	 */
+	protected function isRemoteUser($parameter) {
+		return strpos($parameter, '@') > 0;
 	}
 }

--- a/lib/Parameter/Factory.php
+++ b/lib/Parameter/Factory.php
@@ -128,7 +128,7 @@ class Factory {
 		if ($formatter === 'file') {
 			return new FileFormatter($this->infoCache, $this->urlGenerator, $this->l, $this->user);
 		} else if ($formatter === 'username') {
-			return new UserFormatter($this->userManager, $this->l);
+			return new UserFormatter($this->userManager, $this->l, new CloudIDFormatter($this->contactsManager));
 		} else if ($formatter === 'federated_cloud_id') {
 			return new CloudIDFormatter($this->contactsManager);
 		} else {

--- a/lib/Parameter/Factory.php
+++ b/lib/Parameter/Factory.php
@@ -32,7 +32,6 @@ use OCA\Activity\ViewInfoCache;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\Contacts\IManager as IContactsManager;
-use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -125,14 +124,21 @@ class Factory {
 	 * @return IFormatter
 	 */
 	protected function getFormatter($formatter) {
-		if ($formatter === 'file') {
-			return new FileFormatter($this->infoCache, $this->urlGenerator, $this->l, $this->user);
-		} else if ($formatter === 'username') {
-			return new UserFormatter($this->userManager, $this->l, new CloudIDFormatter($this->contactsManager));
-		} else if ($formatter === 'federated_cloud_id') {
-			return new CloudIDFormatter($this->contactsManager);
-		} else {
-			return new BaseFormatter();
+		switch ($formatter) {
+			case 'file':
+				/** @var \OCA\Activity\Formatter\FileFormatter $fileFormatter */
+				$fileFormatter = \OC::$server->query('OCA\Activity\Formatter\FileFormatter');
+				$fileFormatter->setUser($this->user);
+				return $fileFormatter;
+			case 'username':
+				/** @var \OCA\Activity\Formatter\UserFormatter */
+				return \OC::$server->query('OCA\Activity\Formatter\UserFormatter');
+			case 'federated_cloud_id':
+				/** @var \OCA\Activity\Formatter\CloudIDFormatter */
+				return \OC::$server->query('OCA\Activity\Formatter\CloudIDFormatter');
+			default:
+				/** @var \OCA\Activity\Formatter\BaseFormatter */
+				return \OC::$server->query('OCA\Activity\Formatter\BaseFormatter');
 		}
 	}
 }

--- a/tests/AppInfo/ApplicationTest.php
+++ b/tests/AppInfo/ApplicationTest.php
@@ -61,10 +61,12 @@ class ApplicationTest extends TestCase {
 			array('MailQueueHandler', 'OCA\Activity\MailQueueHandler'),
 			array('Navigation', 'OCA\Activity\Navigation'),
 			array('UserSettings', 'OCA\Activity\UserSettings'),
-			array('OCA\Activity\ViewInfoCache', 'OCA\Activity\ViewInfoCache'),
 			array('SettingsController', 'OCP\AppFramework\Controller'),
 			array('ActivitiesController', 'OCP\AppFramework\Controller'),
 			array('FeedController', 'OCP\AppFramework\Controller'),
+
+			array('OCA\Activity\CurrentUser', 'OCA\Activity\CurrentUser'),
+			array('OCA\Activity\ViewInfoCache', 'OCA\Activity\ViewInfoCache'),
 		);
 	}
 

--- a/tests/CurrentUserTest.php
+++ b/tests/CurrentUserTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Activity\Tests;
+
+
+use OCA\Activity\CurrentUser;
+use OCP\IUser;
+use OCP\Share;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IShare;
+
+/**
+ * Class CurrentUserTest
+ *
+ * @package OCA\Activity\Tests
+ */
+class CurrentUserTest extends TestCase {
+
+	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	protected $request;
+
+	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	protected $userSession;
+
+	/** @var \OCP\Share\IManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $shareManager;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMockBuilder('OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->userSession = $this->getMockBuilder('OCP\IUserSession')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->shareManager = $this->getMockBuilder('OCP\Share\IManager')
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	/**
+	 * @param array $methods
+	 * @return CurrentUser|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected function getInstance(array $methods = []) {
+		if (empty($methods)) {
+			return new CurrentUser(
+				$this->userSession,
+				$this->request,
+				$this->shareManager
+			);
+		} else {
+			return $this->getMockBuilder('OCA\Activity\CurrentUser')
+				->setConstructorArgs([
+					$this->userSession,
+					$this->request,
+					$this->shareManager,
+				])
+				->setMethods($methods)
+				->getMock();
+		}
+	}
+
+	public function dataGetUserIdentifier() {
+		return [
+			[null, null, null, ''],
+			[null, 'uid', -1, 'uid'],
+			[null, null, 'token', 'token'],
+			['cached', -1, -1, 'cached'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetUserIdentifier
+	 *
+	 * @param string|null $cachedIdentifier
+	 * @param string|int|null $uidResult
+	 * @param string|int|null $tokenResult
+	 * @param string $expected
+	 */
+	public function testGetUserIdentifier($cachedIdentifier, $uidResult, $tokenResult, $expected) {
+		$instance = $this->getInstance([
+			'getUID',
+			'getCloudIDFromToken',
+		]);
+
+		$this->invokePrivate($instance, 'identifier', [$cachedIdentifier]);
+
+		$instance->expects($uidResult !== -1 ? $this->once() : $this->never())
+			->method('getUID')
+			->willReturn($uidResult);
+
+		$instance->expects($tokenResult !== -1 ? $this->once() : $this->never())
+			->method('getCloudIDFromToken')
+			->willReturn($tokenResult);
+
+		$this->assertSame($expected, $instance->getUserIdentifier());
+	}
+
+	/**
+	 * @param string $uid
+	 * @return IUser
+	 */
+	protected function getUserMock($uid) {
+		$user = $this->getMockBuilder('OCP\IUser')
+			->disableOriginalConstructor()
+			->getMock();
+		$user->expects($this->once())
+			->method('getUID')
+			->willReturn($uid);
+		return $user;
+	}
+
+	public function dataGetUID() {
+		return [
+			[null, null],
+			[$this->getUserMock('uid'), 'uid'],
+			[$this->getUserMock('test'), 'test'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetUID
+	 *
+	 * @param IUser|null $user
+	 * @param string|null $expected
+	 */
+	public function testGetUID($user, $expected) {
+		$instance = $this->getInstance();
+
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+
+		$this->assertSame($expected, $instance->getUID());
+	}
+
+	/**
+	 * @param int $type
+	 * @param string $shareWith
+	 * @return IShare
+	 */
+	protected function getShareMock($type, $shareWith) {
+		$share = $this->getMockBuilder('OCP\Share\IShare')
+			->disableOriginalConstructor()
+			->getMock();
+		$share->expects($this->once())
+			->method('getShareType')
+			->willReturn($type);
+		$share->expects($shareWith !== null  ? $this->once() : $this->never())
+			->method('getSharedWith')
+			->willReturn($shareWith);
+		return $share;
+	}
+
+	public function dataGetCloudIDFromToken() {
+		return [
+			[[], null, null],
+			[['PHP_AUTH_USER' => 'token23'], $this->getShareMock(Share::SHARE_TYPE_LINK, null), null],
+			[['PHP_AUTH_USER' => 'token32'], new ShareNotFound(), null],
+			[['PHP_AUTH_USER' => 'token42'], $this->getShareMock(Share::SHARE_TYPE_REMOTE, 'test@localhost'), 'test@localhost'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetCloudIDFromToken
+	 *
+	 * @param array $server
+	 * @param IShare|\Exception|null $share
+	 * @param string|null $expected
+	 */
+	public function testGetCloudIDFromToken(array $server, $share, $expected) {
+		$instance = $this->getInstance();
+
+		$this->request->server = $server;
+
+		if ($share === null) {
+			$this->shareManager->expects($this->never())
+				->method('getShareByToken');
+		} else if ($share instanceof \Exception) {
+			$this->shareManager->expects($this->once())
+				->method('getShareByToken')
+				->with($server['PHP_AUTH_USER'])
+				->willThrowException($share);
+		} else {
+			$this->shareManager->expects($this->once())
+				->method('getShareByToken')
+				->with($server['PHP_AUTH_USER'])
+				->willReturn($share);
+		}
+
+		$this->assertSame($expected, $this->invokePrivate($instance, 'getCloudIDFromToken'));
+	}
+}

--- a/tests/Formatter/FileFormatterTest.php
+++ b/tests/Formatter/FileFormatterTest.php
@@ -64,14 +64,15 @@ class FileFormatterTest extends TestCase {
 	 */
 	public function getFormatter(array $methods = [], $user = 'user') {
 		if (empty($methods)) {
-			return new FileFormatter(
+			$formatter = new FileFormatter(
 				$this->infoCache,
 				$this->urlGenerator,
-				$this->l,
-				$user
+				$this->l
 			);
+			$formatter->setUser($user);
+			return $formatter;
 		} else {
-			return $this->getMockBuilder('OCA\Activity\Formatter\FileFormatter')
+			$formatter = $this->getMockBuilder('OCA\Activity\Formatter\FileFormatter')
 				->setConstructorArgs([
 					$this->infoCache,
 					$this->urlGenerator,
@@ -80,6 +81,8 @@ class FileFormatterTest extends TestCase {
 				])
 				->setMethods($methods)
 				->getMock();
+			$this->invokePrivate($formatter, 'user', [$user]);
+			return $formatter;
 		}
 	}
 


### PR DESCRIPTION
- [x] Tests

### Steps
1. Create a federated share
2. As recipient accept the share
3. As recipient upload a file
4. As share owner open the activity feed

### Before
`"remote user" created a.txt`

### After
`test@... created a.txt`

PS: you need to do a new upload, since the value is stored in the DB on upload (it's not only reendering)