### PR TITLE
Fix group detection for sharing activities

### DIFF
--- a/lib/GroupHelper.php
+++ b/lib/GroupHelper.php
@@ -164,7 +164,8 @@ class GroupHelper {
 	 * @return false|string False, if grouping is not allowed, grouping key otherwise
 	 */
 	protected function getGroupKey($activity) {
-		if ($this->getGroupParameter($activity) === false) {
+		$key = $this->getGroupParameter($activity);
+		if ($key === false) {
 			return false;
 		}
 
@@ -176,7 +177,10 @@ class GroupHelper {
 			return false;
 		}
 
-		return $activity['app'] . '|' . $activity['user'] . '|' . $activity['subject'] . '|' . $activity['object_type'];
+		$params = json_decode($activity['subjectparams'], true);
+		unset($params[$key]);
+
+		return $activity['app'] . '|' . $activity['user'] . '|' . $activity['subject'] . '|' . $activity['object_type'] . '|' . md5(json_encode($params));
 	}
 
 	/**

--- a/lib/Parameter/Collection.php
+++ b/lib/Parameter/Collection.php
@@ -50,7 +50,7 @@ class Collection implements IParameter {
 	 */
 	public function addParameter(IParameter $parameter) {
 		foreach ($this->parameters as $existingParameter) {
-			if ($existingParameter->getParameter() === $parameter->getParameter()) {
+			if ($existingParameter->getParameterInfo() === $parameter->getParameterInfo()) {
 				return;
 			}
 		}

--- a/tests/GroupHelperTest.php
+++ b/tests/GroupHelperTest.php
@@ -544,6 +544,7 @@ class GroupHelperTest extends TestCase {
 					'user' => 'user1',
 					'subject' => 'subject1',
 					'object_type' => 'object_type1',
+					'subjectparams' => ['foo', 'bar'],
 				], false, false
 			],
 			[
@@ -552,6 +553,7 @@ class GroupHelperTest extends TestCase {
 					'user' => '',
 					'subject' => 'subject1',
 					'object_type' => 'object_type1',
+					'subjectparams' => ['foo', 'bar'],
 				], 0, false
 			],
 			[
@@ -560,7 +562,8 @@ class GroupHelperTest extends TestCase {
 					'user' => 'user1',
 					'subject' => 'subject1',
 					'object_type' => 'object_type1',
-				], 1, 'app1|user1|subject1|object_type1'
+					'subjectparams' => json_encode(['foo', 'bar']),
+				], 1, 'app1|user1|subject1|object_type1|' . md5(json_encode(['foo']))
 			],
 		];
 	}

--- a/tests/Parameter/CollectionTest.php
+++ b/tests/Parameter/CollectionTest.php
@@ -139,7 +139,7 @@ class CollectionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$parameter1->expects($this->atLeastOnce())
-			->method('getParameter')
+			->method('getParameterInfo')
 			->willReturn('One');
 
 		/** @var \OCA\Activity\Parameter\IParameter|\PHPUnit_Framework_MockObject_MockObject $parameter2 */
@@ -147,7 +147,7 @@ class CollectionTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$parameter2->expects($this->atLeastOnce())
-			->method('getParameter')
+			->method('getParameterInfo')
 			->willReturn('Two');
 
 		$this->assertCount(0, $this->invokePrivate($collection, 'parameters'));


### PR DESCRIPTION
See https://help.nextcloud.com/t/activity-shows-incorrect-actions-when-sharing-folder/2430

### Steps
1. Share 3 different files/folders with the same user/group
2. Check activity stream

@MorrisJobke can you quickly review this?

@karlitschek should backport to 10 and 9