### PR TITLE
Add move rename support

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -109,6 +109,8 @@ class Application extends App {
 		Util::connectHook('OC_Filesystem', 'post_create', FilesHooksStatic::class, 'fileCreate');
 		Util::connectHook('OC_Filesystem', 'post_update', FilesHooksStatic::class, 'fileUpdate');
 		Util::connectHook('OC_Filesystem', 'delete', FilesHooksStatic::class, 'fileDelete');
+		Util::connectHook('OC_Filesystem', 'rename', FilesHooksStatic::class, 'fileMove');
+		Util::connectHook('OC_Filesystem', 'post_rename', FilesHooksStatic::class, 'fileMovePost');
 		Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', FilesHooksStatic::class, 'fileRestore');
 		Util::connectHook('OCP\Share', 'post_shared', FilesHooksStatic::class, 'share');
 		Util::connectHook('OCP\Share', 'pre_unshare', FilesHooksStatic::class, 'unShare');

--- a/lib/FilesHooksStatic.php
+++ b/lib/FilesHooksStatic.php
@@ -34,8 +34,7 @@ class FilesHooksStatic {
 	 * @return FilesHooks
 	 */
 	static protected function getHooks() {
-		$app = new AppInfo\Application();
-		return $app->getContainer()->query(FilesHooks::class);
+		return \OC::$server->query(FilesHooks::class);
 	}
 
 	/**

--- a/lib/FilesHooksStatic.php
+++ b/lib/FilesHooksStatic.php
@@ -63,6 +63,22 @@ class FilesHooksStatic {
 	}
 
 	/**
+	 * Store the rename hook events
+	 * @param array $params The hook params
+	 */
+	public static function fileMove($params) {
+		self::getHooks()->fileMove($params['oldpath'], $params['newpath']);
+	}
+
+	/**
+	 * Store the rename hook events
+	 * @param array $params The hook params
+	 */
+	public static function fileMovePost($params) {
+		self::getHooks()->fileMovePost($params['oldpath'], $params['newpath']);
+	}
+
+	/**
 	 * Store the restore hook events
 	 * @param array $params The hook params
 	 */


### PR DESCRIPTION
### Steps
- [ ] Translation support comes with https://github.com/nextcloud/server/pull/1418

1. Create `test/welcome.txt`
2. Create `test/sub/`
3. Create `test/sub2/`
4. Share `test/` with user test
5. Share `test/sub/` with user foo
6. Share `test/sub2/` with user bar
7. Clear activity table
8. Run [`php moveCross.php`](https://gist.github.com/nickvergessen/19235b684df7eeb9c185f71d204797c1) (DONT WEBDAV MOVE, its a create+delete activity (_not recoverable_))

### Expected
* test has a move activity
* foo has a delete activity
* bar has a create activity

@rullzer want to test? :smiley_cat: 