### PR TITLE
design fixes for tags and avatars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -139,6 +139,7 @@
 	vertical-align: middle;
 	display: inline-block;
 	margin-right: 5px;
+	margin-left: 3px;
 }
 
 .activityTabView .activity.box {

--- a/css/style.css
+++ b/css/style.css
@@ -54,7 +54,7 @@
 	border-radius: 5px;
 }
 
-.group{
+.group {
 	clear: both;
 	padding-bottom: 10px;
 }
@@ -122,8 +122,17 @@
 }
 
 /* Style for in event parameters */
-.activity-section a.filename, .activity-section strong {
+.activity-section a.filename,
+.activity-section strong {
 	font-weight: bold;
+}
+
+.activity-section .icon-tag + .activitysubject strong {
+	display: inline-block;
+	padding: 2px 5px;
+	border-radius: 3px;
+	background-color: #f8f8f8;
+	font-weight: normal;
 }
 
 .activity-section .avatar {


### PR DESCRIPTION
Before
![capture du 2016-10-19 10-54-39](https://cloud.githubusercontent.com/assets/925062/19512111/9bd50666-95ea-11e6-89a5-942e9ee321a5.png)
After: nicer style for tags to be symmetric to how they look elsewhere, and some margin for the avatar:
![capture du 2016-10-19 10-54-13](https://cloud.githubusercontent.com/assets/925062/19512112/9bd66164-95ea-11e6-9d6d-035caddd1177.png)

Please review @nickvergessen @nextcloud/designers 
