### PR TITLE
Fix requirement path in AppTest

### DIFF
--- a/tests/AppInfo/AppTest.php
+++ b/tests/AppInfo/AppTest.php
@@ -36,7 +36,7 @@ class AppTest extends TestCase {
 		$navigationManager->clear();
 		$this->assertEmpty($navigationManager->getAll());
 
-		require '../appinfo/app.php';
+		require 'activity/appinfo/app.php';
 
 		// Test whether the navigation entry got added
 		$this->assertCount(1, $navigationManager->getAll());


### PR DESCRIPTION
With the prior path the requirement is not loaded and the tests fail.
But I don't really know why.

And – shame on me – I'm on Mac and it's not really supported, but if it won't hurt...?
@nickvergessen Care to take a look?