### PR TITLE
Restore the styling of the system tags in the activity stream

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,7 +137,7 @@
 	font-weight: bold;
 }
 
-.activity-section .icon-tag + .activitysubject strong {
+.activitysubject strong.systemtag {
 	display: inline-block;
 	padding: 2px 5px;
 	border-radius: 3px;

--- a/js/richObjectStringParser.js
+++ b/js/richObjectStringParser.js
@@ -16,6 +16,8 @@
 		_fileTemplate: '<a class="filename has-tooltip" href="{{link}}" title="{{title}}">{{name}}</a>',
 		_fileNoPathTemplate: '<a class="filename" href="{{link}}">{{name}}</a>',
 
+		_systemTagTemplate: '<strong class="systemtag">{{name}}</strong>',
+
 		_userTemplate: '<strong>{{name}}</strong>',
 		_userWithAvatarTemplate: '<div class="avatar" data-user="{{id}}" data-user-display-name="{{name}}"></div>',
 
@@ -53,6 +55,22 @@
 			switch (parameter.type) {
 				case 'file':
 					return this.parseFileParameter(parameter);
+
+				case 'systemtag':
+					if (!this.systemTagTemplate) {
+						this.systemTagTemplate = Handlebars.compile(this._systemTagTemplate);
+					}
+
+					var name = parameter.name;
+					if (parameter.visibility !== '1') {
+						name = t('activity', '{name} (invisible)', parameter);
+					} else if (parameter.assignable !== '1') {
+						name = t('activity', '{name} (restricted)', parameter);
+					}
+
+					return this.systemTagTemplate({
+						name: name
+					});
 
 				case 'user':
 					if (!this.userTemplate) {


### PR DESCRIPTION
Bring back the highlight for tags in the stream after https://github.com/nextcloud/server/pull/2179