### PR TITLE
Clarify notify_self filter description

### DIFF
--- a/templates/personal.php
+++ b/templates/personal.php
@@ -63,7 +63,7 @@ style('activity', 'settings');
 	<br />
 	<input id="notify_setting_self" name="notify_setting_self" type="checkbox" class="checkbox"
 		value="1" <?php if ($_['notify_self']): ?> checked="checked"<?php endif; ?> />
-	<label for="notify_setting_self"><?php p($l->t('List your own file actions in the stream')); ?></label>
+	<label for="notify_setting_self"><?php p($l->t('List your own actions in the stream')); ?></label>
 	<br />
 	<input id="notify_setting_selfemail" name="notify_setting_selfemail" type="checkbox" class="checkbox"
 		value="1" <?php if ($_['notify_selfemail']): ?> checked="checked"<?php endif; ?> />


### PR DESCRIPTION
Removed "file" context from checkbox description, as this filter applies also to all actions contributed by other apps.