### PR TITLE
Fix the icon size of events to be max 16px

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -186,6 +186,10 @@
 	filter: alpha(opacity=50);
 	opacity: .5;
 }
+.activity-icon img {
+	max-width: 16px;
+	max-height: 16px;
+}
 
 .activity-icon.icon-add-color {
 	background-image: url('../img/add-color.svg');


### PR DESCRIPTION
16px is intended and all icons so far used it. But the icon of the calendar is 32 pixels, therefor this adjustment is needed.

@MorrisJobke 