### PR TITLE
shorten activity mail wording, fix * for bullets to -, time in parentheses

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -251,7 +251,7 @@ class MailQueueHandler {
 
 			$relativeDateTime = $this->dateFormatter->formatDateTimeRelativeDay(
 				$activity['amq_timestamp'],
-				'long', 'medium',
+				'long', 'short',
 				new \DateTimeZone($timezone), $l
 			);
 

--- a/templates/email.notification.php
+++ b/templates/email.notification.php
@@ -28,16 +28,16 @@ print_unescaped($l->t('Hello %s,', array($_['username'])));
 p("\n");
 p("\n");
 
-print_unescaped($l->t('You are receiving this email because the following things happened at %s', array($_['installation'])));
+print_unescaped($l->t('There was some activity at %s', array($_['installation'])));
 p("\n");
 p("\n");
 
 foreach ($_['activities'] as $activityData) {
-	print_unescaped($l->t('* %1$s - %2$s', $activityData));
+	print_unescaped($l->t('- %1$s (%2$s)', $activityData));
 	p("\n");
 }
 if ($_['skippedCount']) {
-	print_unescaped($l->n('* and %n more ', '* and %n more ', $_['skippedCount']));
+	print_unescaped($l->n('- and %n more ', '- and %n more ', $_['skippedCount']));
 	p("\n");
 }
 p("\n");


### PR DESCRIPTION
Stuff left to do I can’t figure out how to do:

- [ ] remove trailing slash in instance URL (currently `/cloud.example.com/`)
- [x] remove leading slash of any file (currently `/Some document.odt`) => https://github.com/nextcloud/server/pull/2695
- [x] remove seconds from timestamp (currently `today 18:45:00`)
- [ ] don’t show the bullet point `-` when there is only a single activity
- [ ] change title to `Nextcloud activity notification` for when multiple things happened and `Nextcloud: Joas shared Picture.jpg with you` for when it’s a single action. (of course with themed app name)

Can you help there @nickvergessen?