### PR TITLE
Make sure integer like names are still strings

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -163,6 +163,7 @@ class FilesHooks {
 		$filteredEmailUsers = $this->userSettings->filterUsersBySetting(array_keys($affectedUsers), 'email', $activityType);
 
 		foreach ($affectedUsers as $user => $path) {
+			$user = (string) $user;
 			if (empty($filteredStreamUsers[$user]) && empty($filteredEmailUsers[$user])) {
 				continue;
 			}


### PR DESCRIPTION
Fix https://help.nextcloud.com/t/activity-app-seems-no-longer-working/7353/3

@LukasReschke should backport before 11.0.1