### PR TITLE
Add an API to retrieve all filters

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -24,6 +24,7 @@ return [
 		['name' => 'RemoteActivity#receiveActivity', 'url' => '/api/v2/remote/{token}', 'verb' => 'POST'],
 		['name' => 'APIv1#get', 'url' => '/activity', 'verb' => 'GET', 'root' => '/cloud'],
 		['name' => 'APIv2#getDefault', 'url' => '/api/v2/activity', 'verb' => 'GET'],
+		['name' => 'APIv2#listFilters', 'url' => '/api/v2/activity/filters', 'verb' => 'GET'],
 		['name' => 'APIv2#getFilter', 'url' => '/api/v2/activity/{filter}', 'verb' => 'GET'],
 	],
 	'routes' => [

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -42,6 +42,7 @@ class Capabilities implements ICapability {
 			'activity' => [
 				'apiv2' => [
 					'filters',
+					'filters-api',
 					'previews',
 					'rich-strings',
 				],

--- a/tests/CapabilitiesTest.php
+++ b/tests/CapabilitiesTest.php
@@ -34,6 +34,7 @@ class CapabilitiesTest extends TestCase {
 			'activity' => [
 				'apiv2' => [
 					'filters',
+					'filters-api',
 					'previews',
 					'rich-strings',
 				],


### PR DESCRIPTION
Fix #172 

```xml
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message>OK</message>
 </meta>
 <data>
  <element>
   <id>all</id>
   <name>Alle Aktivitäten</name>
   <icon>https://nextcloud13.local/apps/activity/img/activity-dark.svg</icon>
  </element>
  <element>
   <id>self</id>
   <name>Von Dir</name>
   <icon>https://nextcloud13.local/core/img/actions/user.svg</icon>
  </element>
   ...
```