### PR TITLE
Add option to send mails ASAP aka with next cron run

### DIFF
--- a/lib/Command/SendEmails.php
+++ b/lib/Command/SendEmails.php
@@ -97,6 +97,8 @@ class SendEmails extends Command {
 			$restrictEmails = UserSettings::EMAIL_SEND_DAILY;
 		} else if ($restrictBatching === 'weekly') {
 			$restrictEmails = UserSettings::EMAIL_SEND_WEEKLY;
+		} else if ($restrictBatching === 'asap') {
+			$restrictEmails = UserSettings::EMAIL_SEND_ASAP;
 		} else {
 			$restrictEmails = null;
 		}

--- a/lib/Controller/Settings.php
+++ b/lib/Controller/Settings.php
@@ -128,6 +128,8 @@ class Settings extends Controller {
 			$email_batch_time = 3600 * 24;
 		} else if ($notify_setting_batchtime === UserSettings::EMAIL_SEND_WEEKLY) {
 			$email_batch_time = 3600 * 24 * 7;
+		} else if ($notify_setting_batchtime === UserSettings::EMAIL_SEND_ASAP) {
+			$email_batch_time = 0;
 		}
 
 		$this->config->setUserValue(
@@ -188,6 +190,8 @@ class Settings extends Controller {
 			$email_batch_time = 3600 * 24;
 		} else if ($notify_setting_batchtime === UserSettings::EMAIL_SEND_WEEKLY) {
 			$email_batch_time = 3600 * 24 * 7;
+		} else if ($notify_setting_batchtime === UserSettings::EMAIL_SEND_ASAP) {
+			$email_batch_time = 0;
 		}
 
 		$this->config->setAppValue(
@@ -258,6 +262,8 @@ class Settings extends Controller {
 			$settingBatchTime = UserSettings::EMAIL_SEND_WEEKLY;
 		} else if ($currentSetting === 3600 * 24) {
 			$settingBatchTime = UserSettings::EMAIL_SEND_DAILY;
+		} else if ($currentSetting === 0) {
+			$settingBatchTime = UserSettings::EMAIL_SEND_ASAP;
 		}
 
 		return new TemplateResponse('activity', 'settings/personal', [

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -231,6 +231,8 @@ class MailQueueHandler {
 				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' + ' . 3600 * 24)));
 			} else if ($restrictEmails === UserSettings::EMAIL_SEND_WEEKLY) {
 				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' + ' . 3600 * 24 * 7)));
+			} else if ($restrictEmails === UserSettings::EMAIL_SEND_ASAP) {
+				$query->where($query->expr()->eq('amq_timestamp', 'amq_latest_send'));
 			}
 		}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -101,6 +101,8 @@ class Admin implements ISettings {
 			$settingBatchTime = UserSettings::EMAIL_SEND_WEEKLY;
 		} else if ($currentSetting === 3600 * 24) {
 			$settingBatchTime = UserSettings::EMAIL_SEND_DAILY;
+		} else if ($currentSetting === 0) {
+			$settingBatchTime = UserSettings::EMAIL_SEND_ASAP;
 		}
 
 		return new TemplateResponse('activity', 'settings/admin', [

--- a/lib/UserSettings.php
+++ b/lib/UserSettings.php
@@ -43,6 +43,7 @@ class UserSettings {
 	const EMAIL_SEND_HOURLY = 0;
 	const EMAIL_SEND_DAILY = 1;
 	const EMAIL_SEND_WEEKLY = 2;
+	const EMAIL_SEND_ASAP = 3;
 
 	/**
 	 * @param IManager $manager

--- a/templates/settings/form.php
+++ b/templates/settings/form.php
@@ -84,6 +84,7 @@
 	<br />
 	<label for="notify_setting_batchtime"><?php p($l->t('Send emails:')); ?></label>
 	<select id="notify_setting_batchtime" name="notify_setting_batchtime">
+		<option value="3"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_ASAP): ?> selected="selected"<?php endif; ?>><?php p($l->t('As soon as possible')); ?></option>
 		<option value="0"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_HOURLY): ?> selected="selected"<?php endif; ?>><?php p($l->t('Hourly')); ?></option>
 		<option value="1"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_DAILY): ?> selected="selected"<?php endif; ?>><?php p($l->t('Daily')); ?></option>
 		<option value="2"<?php if ($_['setting_batchtime'] === \OCA\Activity\UserSettings::EMAIL_SEND_WEEKLY): ?> selected="selected"<?php endif; ?>><?php p($l->t('Weekly')); ?></option>


### PR DESCRIPTION
Picking up on https://github.com/nextcloud/activity/pull/186

This PR adds an option to send mails out `As soon as possible`.
For example, you can add a cron job
```
 */5  *  *  *  *    php -f /var/www/nextcloud/occ activity:send-mails asap
```
that will send out the mails of all users which selected `As soon as possible` every 5 minutes.