### PR TITLE
Use the usermountcache to get all users who have access to a file

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -210,7 +210,7 @@ class FilesHooks {
 			return $mount->getUser()->getUID();
 		}, $mountsForFile);
 		$affectedPaths = array_map(function (ICachedMountFileInfo $mount) {
-			return $mount->getPath();
+			return $this->getVisiblePath($mount->getPath());
 		}, $mountsForFile);
 		$affectedUsers = array_combine($affectedUserIds, $affectedPaths);
 		$filteredStreamUsers = $this->userSettings->filterUsersBySetting(array_keys($affectedUsers), 'stream', $activityType);
@@ -631,15 +631,20 @@ class FilesHooks {
 		$accessList = $this->shareHelper->getPathsForAccessList($node);
 
 		$path = $node->getPath();
-		$sections = explode('/', $path, 4);
+		$accessList['ownerPath'] = $this->getVisiblePath($path);
+		return $accessList;
+	}
 
-		$accessList['ownerPath'] = '/';
+	protected function getVisiblePath(string $absolutePath): string {
+		$sections = explode('/', $absolutePath, 4);
+
+		$path = '/';
 		if (isset($sections[3])) {
 			// Not the case when a file in root is renamed
-			$accessList['ownerPath'] .= $sections[3];
+			$path .= $sections[3];
 		}
 
-		return $accessList;
+		return $path;
 	}
 
 	/**

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -30,6 +30,7 @@ use OCA\Activity\Tests\TestCase;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IUser;
 use OCP\Share\IShare;
@@ -38,11 +39,11 @@ use OCP\Activity\IManager;
 use OCP\IGroupManager;
 use OC\Files\View;
 use OCP\IURLGenerator;
-use PHPUnit\Framework\MockObject\MockObject;
 use OCP\IGroup;
 use OCA\Files_Sharing\SharedStorage;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Activity\IEvent;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class FilesHooksTest
@@ -70,8 +71,10 @@ class FilesHooksTest extends TestCase {
 	protected $shareHelper;
 	/** @var IURLGenerator|MockObject */
 	protected $urlGenerator;
-	/** @var IUserMountCache|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserMountCache|MockObject */
 	protected $userMountCache;
+	/** @var IConfig|MockObject */
+	protected $config;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -85,6 +88,7 @@ class FilesHooksTest extends TestCase {
 		$this->shareHelper = $this->createMock(IShareHelper::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userMountCache = $this->createMock(IUserMountCache::class);
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->filesHooks = $this->getFilesHooks();
 	}
@@ -119,7 +123,8 @@ class FilesHooksTest extends TestCase {
 					$this->urlGenerator,
 					$logger,
 					$currentUser,
-					$this->userMountCache
+					$this->userMountCache,
+					$this->config,
 				])
 				->onlyMethods($mockedMethods)
 				->getMock();
@@ -137,7 +142,8 @@ class FilesHooksTest extends TestCase {
 			$this->urlGenerator,
 			$logger,
 			$currentUser,
-			$this->userMountCache
+			$this->userMountCache,
+			$this->config
 		);
 	}
 
@@ -245,6 +251,39 @@ class FilesHooksTest extends TestCase {
 					[['user', 'user1', 'user2'], 'stream', Files::TYPE_SHARE_RESTORED, ['user' => true]],
 					[['user', 'user1', 'user2'], 'email', Files::TYPE_SHARE_RESTORED, ['user' => 42]],
 				],
+				'mountcache_used' => false,
+				[
+					'user' => [
+						'subject' => 'restored_self',
+						'subject_params' => [[1337 => '/user/files/path']],
+						'path' => '/user/files/path',
+						'stream' => true,
+						'email' => 42,
+					],
+				],
+			],
+			[
+				[
+					[['user', 'user1', 'user2'], 'stream', Files::TYPE_SHARE_RESTORED, ['user1' => true]],
+					[['user', 'user1', 'user2'], 'email', Files::TYPE_SHARE_RESTORED, []],
+				],
+				'mountcache_used' => false,
+				[
+					'user1' => [
+						'subject' => 'restored_by',
+						'subject_params' => [[1337 => '/user1/files/path'], 'user'],
+						'path' => '/user1/files/path',
+						'stream' => true,
+						'email' => 0,
+					],
+				],
+			],
+			[
+				[
+					[['user', 'user1', 'user2'], 'stream', Files::TYPE_SHARE_RESTORED, ['user' => true]],
+					[['user', 'user1', 'user2'], 'email', Files::TYPE_SHARE_RESTORED, ['user' => 42]],
+				],
+				'mountcache_used' => true,
 				[
 					'user' => [
 						'subject' => 'restored_self',
@@ -260,6 +299,7 @@ class FilesHooksTest extends TestCase {
 					[['user', 'user1', 'user2'], 'stream', Files::TYPE_SHARE_RESTORED, ['user1' => true]],
 					[['user', 'user1', 'user2'], 'email', Files::TYPE_SHARE_RESTORED, []],
 				],
+				'mountcache_used' => true,
 				[
 					'user1' => [
 						'subject' => 'restored_by',
@@ -277,9 +317,10 @@ class FilesHooksTest extends TestCase {
 	 * @dataProvider dataAddNotificationsForFileAction
 	 *
 	 * @param array $filterUsers
+	 * @param bool $mountCacheUsed
 	 * @param array $addNotifications
 	 */
-	public function testAddNotificationsForFileAction(array $filterUsers, array $addNotifications): void {
+	public function testAddNotificationsForFileAction(array $filterUsers, bool $mountCacheUsed, array $addNotifications): void {
 		$filesHooks = $this->getFilesHooks([
 			'getSourcePathAndOwner',
 			'getUserPathsFromPath',
@@ -303,37 +344,47 @@ class FilesHooksTest extends TestCase {
 				'remotes' => [],
 			]);
 
-		$this->userMountCache->expects($this->once())
-			->method('getMountsForFileId')
-			->willReturn([
-				new CachedMountFileInfo(
-					$this->getUserMock('user'),
-					1,
-					1,
-					'/user/files/',
-					null,
-					'',
-					'path'
-				),
-				new CachedMountFileInfo(
-					$this->getUserMock('user1'),
-					1,
-					1,
-					'/user1/files/',
-					null,
-					'',
-					'path'
-				),
-				new CachedMountFileInfo(
-					$this->getUserMock('user2'),
-					1,
-					1,
-					'/user2/files/',
-					null,
-					'',
-					'path'
-				)
-			]);
+		$this->config->expects($this->once())
+			->method('getSystemValueBool')
+			->with('activity_use_cached_mountpoints', false)
+			->willReturn($mountCacheUsed);
+
+		if ($mountCacheUsed) {
+			$this->userMountCache->expects($this->once())
+				->method('getMountsForFileId')
+				->willReturn([
+					new CachedMountFileInfo(
+						$this->getUserMock('user'),
+						1,
+						1,
+						'/user/files/',
+						null,
+						'',
+						'path'
+					),
+					new CachedMountFileInfo(
+						$this->getUserMock('user1'),
+						1,
+						1,
+						'/user1/files/',
+						null,
+						'',
+						'path'
+					),
+					new CachedMountFileInfo(
+						$this->getUserMock('user2'),
+						1,
+						1,
+						'/user2/files/',
+						null,
+						'',
+						'path'
+					)
+				]);
+		} else {
+			$this->userMountCache->expects($this->never())
+				->method('getMountsForFileId');
+		}
 
 		$this->settings->expects($this->exactly(2))
 			->method('filterUsersBySetting')

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -248,8 +248,8 @@ class FilesHooksTest extends TestCase {
 				[
 					'user' => [
 						'subject' => 'restored_self',
-						'subject_params' => [[1337 => '/user/files/path']],
-						'path' => '/user/files/path',
+						'subject_params' => [[1337 => '/path']],
+						'path' => '/path',
 						'stream' => true,
 						'email' => 42,
 					],
@@ -263,8 +263,8 @@ class FilesHooksTest extends TestCase {
 				[
 					'user1' => [
 						'subject' => 'restored_by',
-						'subject_params' => [[1337 => '/user1/files/path'], 'user'],
-						'path' => '/user1/files/path',
+						'subject_params' => [[1337 => '/path'], 'user'],
+						'path' => '/path',
 						'stream' => true,
 						'email' => 0,
 					],


### PR DESCRIPTION
Fixes activity when multiple users have access to the same files *not* trough sharing (but instead external storage, group folders, etc)

- [x] requires https://github.com/nextcloud/server/pull/6220

Fix https://github.com/nextcloud/activity/issues/264
