### PR TITLE
Add metadata to email template

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -351,6 +351,7 @@ class MailQueueHandler {
 		$template->addHeading($l->t('Hello %s',[$user->getDisplayName()]), $l->t('Hello %s,',[$user->getDisplayName()]));
 		$template->addBodyText($l->t('There was some activity at %s', [$this->urlGenerator->getAbsoluteURL('/')]));
 
+		$activityEvents = [];
 		foreach ($mailData as $activity) {
 			$event = $this->activityManager->generateEvent();
 			try {
@@ -374,12 +375,24 @@ class MailQueueHandler {
 				continue;
 			}
 
+			$activityEvents[] = [
+				'event' => $event,
+				'relativeDateTime' => $relativeDateTime
+			];
+
 			$template->addBodyListItem($event->getParsedSubject(), $relativeDateTime, $event->getIcon());
 		}
 
 		if ($skippedCount) {
 			$template->addBodyListItem($l->n('and %n more ', 'and %n more ', $skippedCount));
 		}
+
+		$template->setMetaData('activity.Notification', [
+			'displayname' => $user->getDisplayName(),
+			'url' => $this->urlGenerator->getAbsoluteURL('/'),
+			'activityEvents' => $activityEvents,
+			'skippedCount' => $skippedCount,
+		]);
 
 		$template->addFooter();
 


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/server/pull/6255

cc @oparoz 

Contains then something like this:

```
[
	'displayname' => 'Karl',
	'url' => 'https://example.org',
	'activityEvents' => [['event' => object of type OCP/Activity/IEvent, 'relativeDateTime' => '3 hours ago'], ... ],
	'skippedCount' => 4,
]
```

cc @MariusBluem for the documentation