### PR TITLE
Still generate emails for delay = 0

### DIFF
--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -80,7 +80,7 @@ class Consumer implements IConsumer {
 		$createEmail = !$selfAction || $this->userSettings->getUserSetting($event->getAffectedUser(), 'setting', 'selfemail');
 
 		// Add activity to mail queue
-		if ($emailSetting && $createEmail) {
+		if ($emailSetting !== false && $createEmail) {
 			$latestSend = $event->getTimestamp() + $emailSetting;
 			$this->data->storeMail($event, $latestSend);
 		}


### PR DESCRIPTION
cc @t2d 

Regression from #187 

### Steps
1. Enable comments app
2. Comment on a shared file
3. Check database or activity email

### Actually
there is no entry, because offset `0` equals `false` therefor we need to do the comparison with strict type