### PR TITLE
Properly construct path of root on file rename

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -619,7 +619,8 @@ class FilesHooks {
 		$sections = explode('/', $path, 4);
 
 		$accessList['ownerPath'] = '/';
-		if (count($sections) === 4) {
+		if (isset($sections[3])) {
+			// Not the case when a file in root is renamed
 			$accessList['ownerPath'] .= $sections[3];
 		}
 

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -617,7 +617,11 @@ class FilesHooks {
 
 		$path = $node->getPath();
 		$sections = explode('/', $path, 4);
-		$accessList['ownerPath'] = '/' . $sections[3];
+
+		$accessList['ownerPath'] = '/';
+		if (count($sections) === 4) {
+			$accessList['ownerPath'] .= $sections[3];
+		}
 
 		return $accessList;
 	}


### PR DESCRIPTION
If you have a file in your root folder. And you rename that file. We
will try to find who has access to the parent. In this case the parent
of is the root folder of the user. So sections is only 3 elements big.

Found on our sentry instance.