### PR TITLE
ensure userids are always strings

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -1056,6 +1056,7 @@ class FilesHooks {
 			return;
 		}
 
+		$user = (string)$user;
 		$selfAction = $user === $this->currentUser->getUID();
 		$app = $type === Files_Sharing::TYPE_SHARED ? 'files_sharing' : 'files';
 		$link = $this->urlGenerator->linkToRouteAbsolute('files.view.index', array(


### PR DESCRIPTION
Fixes an ``"InvalidArgumentException\",\"Message\":\"The given affected user is invalid\"``issue.

Repro steps:

1. Have two users with numerical ideas, "12345" and "67890"
2. Let those two users have a shared folder, containing a subfolder and a file
3. Move  the file into the subfolder

Without the patch, the exception ↑ is logged.