### PR TITLE
Don't update personal settings for admins

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -8,7 +8,7 @@ $(document).ready(function() {
 		});
 	}
 
-	var $activityNotifications = $('#activity_notifications');
+	var $activityNotifications = $('#activity_notifications:not(.default-settings)');
 	$activityNotifications.find('input[type=checkbox]').change(saveSettings);
 
 	$activityNotifications.find('select').change(saveSettings);

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -34,7 +34,7 @@ style('activity', 'settings');
 
 </div>
 
-<form class="section" id="activity_notifications">
+<form class="section default-settings" id="activity_notifications">
 
 	<h2><?php p($l->t('Default settings')); ?></h2>
 


### PR DESCRIPTION
Fix  #261

Doesn't happen on master anymore, because the app has it's own personal settings tab there.