### PR TITLE
Use correct icon for Nextcloud 14

### DIFF
--- a/lib/Filter/ByFilter.php
+++ b/lib/Filter/ByFilter.php
@@ -72,7 +72,7 @@ class ByFilter implements IFilter {
 	 * @since 9.2.0
 	 */
 	public function getIcon() {
-		return $this->url->getAbsoluteURL($this->url->imagePath('core', 'places/contacts-dark.svg'));
+		return $this->url->getAbsoluteURL($this->url->imagePath('core', 'places/contacts.svg'));
 	}
 
 	/**


### PR DESCRIPTION
Fixes loading of the activity app that was caused by the removal of the contacts-dark icon file in https://github.com/nextcloud/server/pull/9984