### PR TITLE
Make the object information available on emails

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 		More information is available in the Activity documentation.
 	</description>
 
-	<version>2.8.0</version>
+	<version>2.8.1</version>
 	<licence>agpl</licence>
 	<author>Frank Karlitschek</author>
 	<author>Joas Schilling</author>

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -358,7 +358,8 @@ class MailQueueHandler {
 				$event->setApp($activity['amq_appid'])
 					->setType($activity['amq_type'])
 					->setTimestamp((int) $activity['amq_timestamp'])
-					->setSubject($activity['amq_subject'], json_decode($activity['amq_subjectparams'], true));
+					->setSubject($activity['amq_subject'], json_decode($activity['amq_subjectparams'], true))
+					->setObject($activity['object_type'], (int) $activity['object_id']);
 			} catch (\InvalidArgumentException $e) {
 				continue;
 			}

--- a/lib/Migration/Version2008Date20181011095117.php
+++ b/lib/Migration/Version2008Date20181011095117.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018, Joas Schilling <coding@schilljs.com>
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Activity\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version2008Date20181011095117 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		try {
+			$table = $schema->getTable('activity_mq');
+		} catch (SchemaException $e) {
+			return null;
+		}
+
+		$table->addColumn('object_type', Type::STRING, [
+			'notnull' => false,
+			'length' => 255,
+		]);
+		$table->addColumn('object_id', Type::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+			'default' => 0,
+		]);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
This would also bring back the subject of announcements in emails.
Let's do this additionally since it's a more general fix.
But this will go into 15 only because of the database changes.

Rel https://github.com/nextcloud/announcementcenter/pull/117