### PR TITLE
Shorten tab label 'Activities' to 'Activity'

### DIFF
--- a/js/activitytabview.js
+++ b/js/activitytabview.js
@@ -53,7 +53,7 @@
 		},
 
 		getLabel: function() {
-			return t('activity', 'Activities');
+			return t('activity', 'Activity');
 		},
 
 		getIcon: function() {


### PR DESCRIPTION
We have limited space in the sidebar (am working on something). "Activity" is used elsewhere too, and it’s a proper word for this. :)

Please review @nickvergessen @juliushaertl 