### PR TITLE
Correctly restrict affected users when using command to send emails

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -231,11 +231,11 @@ class MailQueueHandler {
 
 		if ($restrictEmails !== null) {
 			if ($restrictEmails === UserSettings::EMAIL_SEND_HOURLY) {
-				$query->where($query->expr()->lte('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' + ' . 3600)));
+				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' - ' . 3600)));
 			} else if ($restrictEmails === UserSettings::EMAIL_SEND_DAILY) {
-				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' + ' . 3600 * 24)));
+				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' - ' . 3600 * 24)));
 			} else if ($restrictEmails === UserSettings::EMAIL_SEND_WEEKLY) {
-				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' + ' . 3600 * 24 * 7)));
+				$query->where($query->expr()->eq('amq_timestamp', $query->createFunction($query->getColumnName('amq_latest_send') . ' - ' . 3600 * 24 * 7)));
 			} else if ($restrictEmails === UserSettings::EMAIL_SEND_ASAP) {
 				$query->where($query->expr()->eq('amq_timestamp', 'amq_latest_send'));
 			}


### PR DESCRIPTION
When invoking 'occ activity:send-mails <restrict-batching>' correctly download affected users: amq_timestamp = amq_latest_send - batchtime