### PR TITLE
Added Webhooks methods to complement Stream and E-Mail notifications.

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -25,3 +25,11 @@ table.activitysettings td.small label {
 .nav-icon-activity {
 	background-image: url('../img/activity-dark.svg?v=1');
 }
+
+#webhook_settings_form {
+	display:inline-block;
+}
+
+#webhook_url {
+	width: 260px;
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -32,5 +32,31 @@ $(document).ready(function() {
 			'activity', 'enable_email',
 			$(this).attr('checked') === 'checked' ? 'yes' : 'no'
 		);
-	})
+	});
+
+	$('#activity_webhook_enabled').on('change', function() {
+		OCP.AppConfig.setValue(
+			'activity', 'enable_webhook',
+			$(this).attr('checked') === 'checked' ? 'yes' : 'no'
+		);
+	});
+
+	$('#activity_webhook_ssl_verification').on('change', function() {
+		OCP.AppConfig.setValue(
+			'activity', 'webhook_ssl_verification_enabled',
+			$(this).attr('checked') === 'checked' ? 'yes' : 'no'
+		);
+	});
+
+	$('#webhook_settings_form').on('submit', function(event) {
+		event.preventDefault();
+		OCP.AppConfig.setValue(
+			'activity', 'webhook_url',
+			$("#webhook_url").val()
+		);
+		OCP.AppConfig.setValue(
+			'activity', 'webhook_token',
+			$("#webhook_token").val()
+		);
+	});
 });

--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -66,6 +66,7 @@ class Consumer implements IConsumer {
 		$selfAction = $event->getAffectedUser() === $event->getAuthor();
 		$streamSetting = $this->userSettings->getUserSetting($event->getAffectedUser(), 'stream', $event->getType());
 		$emailSetting = $this->userSettings->getUserSetting($event->getAffectedUser(), 'email', $event->getType());
+		$webhookSetting = $this->userSettings->getUserSetting($event->getAffectedUser(), 'webhook', $event->getType());
 		$emailSetting = ($emailSetting) ? $this->userSettings->getUserSetting($event->getAffectedUser(), 'setting', 'batchtime') : false;
 
 		// User is not the author or wants to see their own actions
@@ -74,6 +75,10 @@ class Consumer implements IConsumer {
 		// Add activity to stream
 		if ($streamSetting && $createStream) {
 			$this->data->send($event);
+		}
+
+		if($webhookSetting) {
+			$this->data->sendWebhookRequest($event);
 		}
 
 		// User is not the author or wants to see their own actions

--- a/lib/Controller/Settings.php
+++ b/lib/Controller/Settings.php
@@ -105,6 +105,7 @@ class Settings extends Controller {
 			$notify_setting_selfemail = false) {
 
 		$settings = $this->manager->getSettings();
+		$webhookEnabled = $this->config->getAppValue('activity', 'enable_webhook', 'no') === 'yes';
 		foreach ($settings as $setting) {
 			if ($setting->canChangeStream()) {
 				$this->config->setUserValue(
@@ -119,6 +120,14 @@ class Settings extends Controller {
 					$this->user, 'activity',
 					'notify_email_' . $setting->getIdentifier(),
 					(int) $this->request->getParam($setting->getIdentifier() . '_email', false)
+				);
+			}
+
+			if ($webhookEnabled) {
+				$this->config->setUserValue(
+					$this->user, 'activity',
+					'notify_webhook_' . $setting->getIdentifier(),
+					(int) $this->request->getParam($setting->getIdentifier() . '_webhook', false)
 				);
 			}
 		}
@@ -167,6 +176,7 @@ class Settings extends Controller {
 			$notify_setting_selfemail = false) {
 
 		$settings = $this->manager->getSettings();
+		$webhookEnabled = $this->config->getAppValue('activity', 'enable_webhook', 'no') === 'yes';
 		foreach ($settings as $setting) {
 			if ($setting->canChangeStream()) {
 				$this->config->setAppValue(
@@ -181,6 +191,14 @@ class Settings extends Controller {
 					'activity',
 					'notify_email_' . $setting->getIdentifier(),
 					(int) $this->request->getParam($setting->getIdentifier() . '_email', false)
+				);
+			}
+
+			if ($webhookEnabled) {
+				$this->config->setAppValue(
+					'activity',
+					'notify_webhook_' . $setting->getIdentifier(),
+					(int) $this->request->getParam($setting->getIdentifier() . '_webhook', false)
 				);
 			}
 		}

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -42,13 +42,17 @@ class Data {
 	/** @var IDBConnection */
 	protected $connection;
 
+	/** @var WebhookHelper */
+	protected $webhookHelper;
+
 	/**
 	 * @param IManager $activityManager
 	 * @param IDBConnection $connection
 	 */
-	public function __construct(IManager $activityManager, IDBConnection $connection) {
+	public function __construct(IManager $activityManager, IDBConnection $connection, WebhookHelper $webhookHelper) {
 		$this->activityManager = $activityManager;
 		$this->connection = $connection;
+		$this->webhookHelper = $webhookHelper;
 	}
 
 	/**
@@ -99,6 +103,32 @@ class Data {
 			])
 			->execute();
 
+		return true;
+	}
+
+	/**
+	 * Send an http(s) request for the event to the webhook url
+	 *
+	 * @param IEvent $event
+	 * @return bool
+	 */
+	public function sendWebhookRequest(IEvent $event) {
+		$content = [
+				'app' => $event->getApp(),
+				'type' => $event->getType(),
+				'affecteduser' => $event->getAffectedUser(),
+				'user' => $event->getAuthor(),
+				'timestamp' => (int) $event->getTimestamp(),
+				'subject' => $event->getSubject(),
+				'subjectparams' => $event->getSubjectParameters(),
+				'message' => $event->getMessage(),
+				'messageparams' => $event->getMessageParameters(),
+				'object_type' => $event->getObjectType(),
+				'object_id' => (int) $event->getObjectId(),
+				'object_name' => $event->getObjectName(),
+				'link' => $event->getLink(),
+			];
+		$this->webhookHelper->sendWebhookRequest($content);
 		return true;
 	}
 

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -220,6 +220,7 @@ class FilesHooks {
 				$fileId, $path, true,
 				!empty($filteredStreamUsers[$user]),
 				$filteredEmailUsers[$user] ?? false,
+				$this->userSettings->filterUsersBySetting(array_keys($affectedUsers), 'webhook', $activityType),
 				$activityType
 			);
 		}
@@ -405,6 +406,7 @@ class FilesHooks {
 				$fileId, $path . '/' . $fileName, true,
 				!empty($filteredStreamUsers[$user]),
 				$filteredEmailUsers[$user] ?? false,
+				$this->userSettings->filterUsersBySetting(array_keys($affectedUsers), 'webhook', Files::TYPE_SHARE_CHANGED),
 				Files::TYPE_SHARE_CHANGED
 			);
 		}
@@ -505,6 +507,7 @@ class FilesHooks {
 				$fileId, $path . '/' . $oldFileName, true,
 				!empty($filteredStreamUsers[$user]),
 				$filteredEmailUsers[$user] ?? false,
+				$this->userSettings->filterUsersBySetting($users, 'webhook', Files::TYPE_SHARE_DELETED),
 				Files::TYPE_SHARE_DELETED
 			);
 		}
@@ -544,6 +547,7 @@ class FilesHooks {
 				$fileId, $path . '/' . $fileName, true,
 				!empty($filteredStreamUsers[$user]),
 				$filteredEmailUsers[$user] ?? false,
+				$this->userSettings->filterUsersBySetting($users, 'webhook', Files::TYPE_SHARE_CREATED),
 				Files::TYPE_SHARE_CREATED
 			);
 		}
@@ -590,6 +594,7 @@ class FilesHooks {
 				$fileId, $afterPathMap[$user] . '/' . $fileName, true,
 				!empty($filteredStreamUsers[$user]),
 				$filteredEmailUsers[$user] ?? false,
+				$this->userSettings->filterUsersBySetting($users, 'webhook', Files::TYPE_SHARE_CHANGED),
 				Files::TYPE_SHARE_CHANGED
 			);
 		}
@@ -703,7 +708,8 @@ class FilesHooks {
 			$shareWith, 'shared_with_by', [[$fileSource => $fileTarget], $this->currentUser->getUserIdentifier()],
 			(int) $fileSource, $fileTarget, $itemType === 'file',
 			$this->userSettings->getUserSetting($shareWith, 'stream', Files_Sharing::TYPE_SHARED),
-			$this->userSettings->getUserSetting($shareWith, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($shareWith, 'setting', 'batchtime') : false
+			$this->userSettings->getUserSetting($shareWith, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($shareWith, 'setting', 'batchtime') : false,
+			$this->userSettings->getUserSetting($shareWith, 'webhook', Files_Sharing::TYPE_SHARED)
 		);
 	}
 
@@ -760,7 +766,8 @@ class FilesHooks {
 			$linkOwner, 'shared_link_self', [[$fileSource => $path]],
 			(int) $fileSource, $path, $itemType === 'file',
 			$this->userSettings->getUserSetting($linkOwner, 'stream', Files_Sharing::TYPE_SHARED),
-			$this->userSettings->getUserSetting($linkOwner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($linkOwner, 'setting', 'batchtime') : false
+			$this->userSettings->getUserSetting($linkOwner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($linkOwner, 'setting', 'batchtime') : false,
+			$this->userSettings->getUserSetting($linkOwner, 'webhook', Files_Sharing::TYPE_SHARED)
 		);
 	}
 
@@ -806,7 +813,8 @@ class FilesHooks {
 			$share->getSharedWith(), 'unshared_by', [[$share->getNodeId() => $share->getTarget()], $this->currentUser->getUserIdentifier()],
 			$share->getNodeId(), $share->getTarget(), $share->getNodeType() === 'file',
 			$this->userSettings->getUserSetting($share->getSharedWith(), 'stream', Files_Sharing::TYPE_SHARED),
-			$this->userSettings->getUserSetting($share->getSharedWith(), 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($share->getSharedWith(), 'setting', 'batchtime') : false
+			$this->userSettings->getUserSetting($share->getSharedWith(), 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($share->getSharedWith(), 'setting', 'batchtime') : false,
+			$this->userSettings->getUserSetting($share->getSharedWith(), 'webhook', Files_Sharing::TYPE_SHARED)
 		);
 	}
 
@@ -875,7 +883,9 @@ class FilesHooks {
 			$owner, $actionSharer, [[$share->getNodeId() => $share->getTarget()]],
 			$share->getNodeId(), $share->getTarget(), $share->getNodeType() === 'file',
 			$this->userSettings->getUserSetting($owner, 'stream', Files_Sharing::TYPE_SHARED),
-			$this->userSettings->getUserSetting($owner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($owner, 'setting', 'batchtime') : false
+			$this->userSettings->getUserSetting($owner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($owner, 'setting', 'batchtime') : false,
+			
+			$this->userSettings->getUserSetting($owner, 'webhook', Files_Sharing::TYPE_SHARED)
 		);
 
 		if ($share->getSharedBy() !== $share->getShareOwner()) {
@@ -884,7 +894,8 @@ class FilesHooks {
 				$owner, $actionOwner, [[$share->getNodeId() => $share->getTarget()], $share->getSharedBy()],
 				$share->getNodeId(), $share->getTarget(), $share->getNodeType() === 'file',
 				$this->userSettings->getUserSetting($owner, 'stream', Files_Sharing::TYPE_SHARED),
-				$this->userSettings->getUserSetting($owner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($owner, 'setting', 'batchtime') : false
+				$this->userSettings->getUserSetting($owner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($owner, 'setting', 'batchtime') : false,
+				$this->userSettings->getUserSetting($owner, 'webhook', Files_Sharing::TYPE_SHARED)
 			);
 		}
 	}
@@ -925,7 +936,8 @@ class FilesHooks {
 				$user, $actionUser, [[$fileSource => $path], $this->currentUser->getUserIdentifier()],
 				$fileSource, $path, ($itemType === 'file'),
 				!empty($filteredStreamUsersInGroup[$user]),
-				$filteredEmailUsersInGroup[$user] ?? false
+				$filteredEmailUsersInGroup[$user] ?? false,
+				$this->userSettings->filterUsersBySetting($userIds, 'webhook', Files_Sharing::TYPE_SHARED)
 			);
 		}
 	}
@@ -979,7 +991,8 @@ class FilesHooks {
 			$sharer, $subject, [[$fileSource => $path], $shareWith],
 			$fileSource, $path, ($itemType === 'file'),
 			$this->userSettings->getUserSetting($sharer, 'stream', Files_Sharing::TYPE_SHARED),
-			$this->userSettings->getUserSetting($sharer, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($sharer, 'setting', 'batchtime') : false
+			$this->userSettings->getUserSetting($sharer, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($sharer, 'setting', 'batchtime') : false,
+			$this->userSettings->getUserSetting($sharer, 'webhook', Files_Sharing::TYPE_SHARED)
 		);
 	}
 
@@ -1005,7 +1018,8 @@ class FilesHooks {
 			$owner, $subject, [[$fileSource => $path], $this->currentUser->getUserIdentifier(), $shareWith],
 			$fileSource, $path, ($itemType === 'file'),
 			$this->userSettings->getUserSetting($owner, 'stream', Files_Sharing::TYPE_SHARED),
-			$this->userSettings->getUserSetting($owner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($owner, 'setting', 'batchtime') : false
+			$this->userSettings->getUserSetting($owner, 'email', Files_Sharing::TYPE_SHARED) ? $this->userSettings->getUserSetting($owner, 'setting', 'batchtime') : false,
+			$this->userSettings->getUserSetting($owner, 'webhook', Files_Sharing::TYPE_SHARED)
 		);
 	}
 
@@ -1070,9 +1084,10 @@ class FilesHooks {
 	 * @param bool $isFile If the item is a file, we link to the parent directory
 	 * @param bool $streamSetting
 	 * @param int $emailSetting
+	 * @param bool $webhookSetting
 	 * @param string $type
 	 */
-	protected function addNotificationsForUser($user, $subject, $subjectParams, $fileId, $path, $isFile, $streamSetting, $emailSetting, $type = Files_Sharing::TYPE_SHARED) {
+	protected function addNotificationsForUser($user, $subject, $subjectParams, $fileId, $path, $isFile, $streamSetting, $emailSetting, $webhookSetting, $type = Files_Sharing::TYPE_SHARED) {
 		if (!$streamSetting && !$emailSetting) {
 			return;
 		}
@@ -1113,6 +1128,10 @@ class FilesHooks {
 		if ($emailSetting !== false && (!$selfAction || $this->userSettings->getUserSetting($this->currentUser->getUID(), 'setting', 'selfemail'))) {
 			$latestSend = time() + $emailSetting;
 			$this->activityData->storeMail($event, $latestSend);
+		}
+
+		if($webhookSetting) {
+			$this->activityData->sendWebhookRequest($event);
 		}
 	}
 }

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -84,6 +84,7 @@ class Admin implements ISettings {
 			if ($setting->canChangeMail()) {
 				$methods[] = IExtension::METHOD_MAIL;
 			}
+			$methods[] = 'webhook';
 
 			$identifier = $setting->getIdentifier();
 
@@ -91,6 +92,7 @@ class Admin implements ISettings {
 				'desc'		=> $setting->getName(),
 				IExtension::METHOD_MAIL		=> $this->userSettings->getConfigSetting('email', $identifier),
 				IExtension::METHOD_STREAM	=> $this->userSettings->getConfigSetting('stream', $identifier),
+				'webhook'	=> $this->userSettings->getConfigSetting('webhook', $identifier),
 				'methods'	=> $methods,
 			);
 		}
@@ -110,6 +112,10 @@ class Admin implements ISettings {
 			'activities'		=> $activities,
 			'is_email_set'		=> true,
 			'email_enabled'		=> $this->config->getAppValue('activity', 'enable_email', 'yes') === 'yes',
+			'webhook_enabled'	=> $this->config->getAppValue('activity', 'enable_webhook', 'no') === 'yes',
+			'webhook_url'		=> $this->config->getAppValue('activity', 'webhook_url', ''),
+			'webhook_token'		=> $this->config->getAppValue('activity', 'webhook_token', ''),
+			'webhook_ssl_verification_enabled'		=> $this->config->getAppValue('activity', 'webhook_ssl_verification_enabled', 'yes') === 'yes',
 
 			'setting_batchtime'	=> $settingBatchTime,
 
@@ -119,6 +125,7 @@ class Admin implements ISettings {
 			'methods'			=> [
 				IExtension::METHOD_MAIL => $this->l10n->t('Mail'),
 				IExtension::METHOD_STREAM => $this->l10n->t('Stream'),
+				'webhook' => $this->l10n->t('Webhook'),
 			],
 		], 'blank');
 	}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -83,9 +83,10 @@ class Personal implements ISettings {
 			return $a->getPriority() > $b->getPriority();
 		});
 
+		$webhookEnabled = $this->config->getAppValue('activity', 'enable_webhook', 'no') === 'yes';
 		$activities = [];
 		foreach ($settings as $setting) {
-			if (!$setting->canChangeStream() && !$setting->canChangeMail()) {
+			if (!$setting->canChangeStream() && !$setting->canChangeMail() && !$webhookEnabled) {
 				// No setting can be changed => don't display
 				continue;
 			}
@@ -97,6 +98,9 @@ class Personal implements ISettings {
 			if ($setting->canChangeMail()) {
 				$methods[] = IExtension::METHOD_MAIL;
 			}
+			if ($webhookEnabled) {
+				$methods[] = 'webhook';
+			}
 
 			$identifier = $setting->getIdentifier();
 
@@ -104,6 +108,7 @@ class Personal implements ISettings {
 				'desc'		=> $setting->getName(),
 				IExtension::METHOD_MAIL		=> $this->userSettings->getUserSetting($this->user, 'email', $identifier),
 				IExtension::METHOD_STREAM	=> $this->userSettings->getUserSetting($this->user, 'stream', $identifier),
+				'webhook'	=> $this->userSettings->getUserSetting($this->user, 'webhook', $identifier),
 				'methods'	=> $methods,
 			);
 		}
@@ -128,6 +133,9 @@ class Personal implements ISettings {
 			$methods = [
 				IExtension::METHOD_STREAM => $this->l10n->t('Stream'),
 			];
+		}
+		if ($webhookEnabled) {
+			$methods['webhook'] = $this->l10n->t('Webhook');
 		}
 
 		return new TemplateResponse('activity', 'settings/personal', [

--- a/lib/WebhookHelper.php
+++ b/lib/WebhookHelper.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Tinko Bartels <mail@tinkobartels.de>
+ *
+ * @author Tinko Bartels <mail@tinkobartels.de>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Activity;
+
+use OCP\IConfig;
+use OCP\ILogger;
+
+class WebhookHelper {
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var ILogger */
+	protected $logger;
+
+	/**
+	 * @param IConfig $config
+	 * @param ILogger $logger
+	 */
+	public function __construct(IConfig $config, ILogger $logger) {
+		$this->config = $config;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param array $content
+	 */
+	public function sendWebhookRequest($content) {
+		$url = $this->config->getAppValue('activity', 'webhook_url', '');
+		$token = $this->config->getAppValue('activity', 'webhook_token', '');
+		$ssl_verification = $this->config->getAppValue('activity', 'webhook_ssl_verification_enabled', 'yes') === 'yes';
+		$content_string = json_encode($content);                                                                                   
+		$headers = array( 'X-Nextcloud-Token: '.$token, 'Content-Type: application/json', 'Content-Length: '.strlen($content_string) );
+		$ch = curl_init();
+		curl_setopt($ch,CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $content_string);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $ssl_verification?2:0);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $ssl_verification);
+		$result = curl_exec($ch);
+		$httpCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+		if(curl_error($ch)) {
+    			$error_msg = curl_error($ch);
+			$this->logger->error("Webhook-Error: ".$error_msg);
+		}
+		if($httpCode>=400) {
+			$this->logger->error("Webhook-Error: HTTP code ".$httpCode);
+		}
+		curl_close($ch);
+	}
+
+}

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -28,9 +28,30 @@ style('activity', 'settings');
 
 	<h2><?php p($l->t('Activity')); ?></h2>
 
+
+	<input id="activity_webhook_enabled" name="activity_webhook_enabled" type="checkbox" class="checkbox"
+		   value="1" <?php if ($_['webhook_enabled']) { print_unescaped('checked="checked"'); } ?> />
+	<label for="activity_webhook_enabled"><?php p($l->t('Send activity HTTP(S) requests:')); ?></label>
+
+	<form id="webhook_settings_form">
+		<label>
+			<input id="webhook_url" type="url" placeholder="https://..." value="<?php p($_['webhook_url']) ?>" maxlength="250" />
+		</label>
+		<label>
+			<input id="webhook_token" type="text" placeholder="<?php p($l->t('Secret (optional)')); ?>" value="<?php p($_['webhook_token']) ?>" maxlength="250" />
+		</label>
+		<input id="webhook_save" type="submit" class="button" value="<?php p($l->t('Save')); ?>">
+	</form>
+	<br />
+
+	<input id="activity_webhook_ssl_verification" name="activity_webhook_ssl_verification" type="checkbox" class="checkbox"
+		   value="1" <?php if ($_['webhook_ssl_verification_enabled']) { print_unescaped('checked="checked"'); } ?> />
+	<label for="activity_webhook_ssl_verification"><?php p($l->t('Webhook SSL Verification')); ?></label>
+	<br />
 	<input id="activity_email_enabled" name="activity_email_enabled" type="checkbox" class="checkbox"
 		   value="1" <?php if ($_['email_enabled']) { print_unescaped('checked="checked"'); } ?> />
 	<label for="activity_email_enabled"><?php p($l->t('Send activity emails')); ?></label>
+
 
 </div>
 


### PR DESCRIPTION
The commit in this pull request adds the feature to send HTTP(S) requests to a URL that is specified in the admin settings as a notification for new activities, similar to the existing methods of sending notifications about new activities via stream or e-mail. The request contains information about the event in JSON format and optionally a secret string that can be set in the Admin settings and can be verified on the receiving end.

Signed-off-by: Tinko Bartels <mail@tinkobartels.de>