### PR TITLE
Move to SCSS and fix app icon for dark theme

### DIFF
--- a/css/settings.scss
+++ b/css/settings.scss
@@ -23,5 +23,5 @@ table.activitysettings td.small label {
 }
 
 .nav-icon-activity {
-	background-image: url('../img/activity-dark.svg?v=1');
+	@include icon-color('activity-dark', 'activity', $color-black);
 }

--- a/css/style.scss
+++ b/css/style.scss
@@ -184,7 +184,7 @@
 }
 
 .icon-activity {
-	background-image: url('../img/activity-dark.svg?v=1');
+	@include icon-color('activity-dark', 'activity', $color-black);
 }
 /* colored icons, in addition to core ones */
 .activity-icon {


### PR DESCRIPTION
This fixes at least the tab header in the files app:
![darktheme files tabs activity header](https://user-images.githubusercontent.com/925062/51315468-899e3c80-1a52-11e9-9079-095469ba99c9.png)
![activity sidebar fix](https://user-images.githubusercontent.com/925062/51315471-899e3c80-1a52-11e9-96c0-24d27c3eb736.png)

For the stream icons more work needs to be done. Follow-up issue at **Stream icons not visible in dark theme #335**