### PR TITLE
Only apply .box and .group class styles if they are related to activity

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -52,72 +52,74 @@
 	border-radius: 5px;
 }
 
-.group {
+.activity-section .group {
 	clear: both;
 	padding-bottom: 10px;
 }
 
-.box {
+.activity.box {
 	width: 100%;
 	display: block;
 	margin-bottom: 10px;
+
+	.header{
+		height: 32px;
+		margin-bottom: 10px;
+	}
+
+	.messagecontainer{
+		width: 100%;
+		display: block;
+		margin-bottom: 20px;
+	}
+
+	.preview{
+		width: 50px;
+		height: 50px;
+		margin-right: 12px;
+	}
+
+	.preview-dir-icon,
+	.preview-mimetype-icon {
+		width: 50px;
+		height: 50px;
+	}
+
+	.user{
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		float: left;
+		display: inline-block;
+		width: 180px;
+		font-weight: bold;
+	}
+
+	.activitytime {
+		float: right;
+		color:#666;
+		font-size: 0.8em;
+		padding: 20px;
+		margin: -20px;
+	}
+
+	.appname {
+		float: right;
+		color: #333;
+		font-size: 0.8em;
+	}
+
+	.grouped{
+		list-style: none;
+	}
+
+	.grouped .more{
+		cursor: default;
+		color: #666;
+	}
 }
 
-.box .header{
-	height: 32px;
-	margin-bottom: 10px;
-}
 
-.box .messagecontainer{
-	width: 100%;
-	display: block;
-	margin-bottom: 20px;
-}
-
-.box .preview{
-	width: 50px;
-	height: 50px;
-	margin-right: 12px;
-}
-
-.box .preview-dir-icon,
-.box .preview-mimetype-icon {
-	width: 50px;
-	height: 50px;
-}
-
-.box .user{
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	float: left;
-	display: inline-block;
-	width: 180px;
-	font-weight: bold;
-}
-
-.box .activitytime {
-	float: right;
-	color:#666;
-	font-size: 0.8em;
-	padding: 20px;
-	margin: -20px;
-}
-
-.box .appname {
-	float: right;
-	color: #333;
-	font-size: 0.8em;
-}
-
-.box .grouped{
-	list-style: none;
-}
-
-.box .grouped .more{
-	cursor: default;
-	color: #666;
-}
 
 /* Navigation icons */
 #app-navigation img {


### PR DESCRIPTION
`.group` is also used in the files sharing dialog, so the css rules should only apply if they are activity related.

Found when testing https://github.com/nextcloud/server/pull/14180