### PR TITLE
Don't overwrite user settings on login

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -72,7 +72,7 @@ class Hooks {
 
 	static public function setDefaultsForUser($params) {
 		$config = \OC::$server->getConfig();
-		if ($config->getUserValue($params['uid'], 'activity', 'configured', null) !== null) {
+		if ($config->getUserValue($params['uid'], 'activity', 'configured', 'no') === 'yes') {
 			// Already has settings
 			return;
 		}
@@ -95,8 +95,8 @@ class Hooks {
 			);
 		}
 
-		// Mark settings as set
-		$config->setUserValue($params['uid'], 'activity', 'configured', '1');
+		// Mark settings as configured
+		$config->setUserValue($params['uid'], 'activity', 'configured', 'yes');
 	}
 
 	/**

--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -72,13 +72,18 @@ class Hooks {
 
 	static public function setDefaultsForUser($params) {
 		$config = \OC::$server->getConfig();
-		if ($config->getUserValue($params['uid'], 'activity','notify_setting_batchtime', null) !== null) {
+		if ($config->getUserValue($params['uid'], 'activity', 'configured', null) !== null) {
 			// Already has settings
 			return;
 		}
 
 		foreach ($config->getAppKeys('activity') as $key) {
 			if (strpos($key, 'notify_') !== 0) {
+				continue;
+			}
+
+			if ($config->getUserValue($params['uid'], 'activity', $key, null) !== null) {
+				// Already has this setting
 				continue;
 			}
 
@@ -89,6 +94,9 @@ class Hooks {
 				$config->getAppValue('activity', $key)
 			);
 		}
+
+		// Mark settings as set
+		$config->setUserValue($params['uid'], 'activity', 'configured', '1');
 	}
 
 	/**


### PR DESCRIPTION
Using `notify_setting_batchtime` to detect whether all app settings of a particular user have been set already isn't the best solution, since it makes it impossible to change a user's app settings (e.g. via CLI) before his first login. This commit introduces a new (hidden) `configured` setting to check whether all settings have been set already. If they haven't, they are set, but existing settings won't be overwritten.