### PR TITLE
is_dir can be null on blacklisted files

### DIFF
--- a/lib/Controller/APIv2.php
+++ b/lib/Controller/APIv2.php
@@ -357,7 +357,7 @@ class APIv2 extends OCSController {
 		}
 
 		$preview = [
-			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'] ?? false, $info['view']),
+			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'], $info['view']),
 			'source'		=> '',
 			'mimeType'		=> 'application/octet-stream',
 			'isMimeTypeIcon' => true,
@@ -395,7 +395,7 @@ class APIv2 extends OCSController {
 	protected function getPreviewFromPath(int $fileId, string $filePath, array $info): array {
 		$mimeType = $info['is_dir'] ? 'dir' : $this->mimeTypeDetector->detectPath($filePath);
 		return [
-			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'] ?? false, $info['view']),
+			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'], $info['view']),
 			'source'		=> $this->getPreviewPathFromMimeType($mimeType),
 			'mimeType'		=> $mimeType,
 			'isMimeTypeIcon' => true,

--- a/lib/Controller/APIv2.php
+++ b/lib/Controller/APIv2.php
@@ -357,7 +357,7 @@ class APIv2 extends OCSController {
 		}
 
 		$preview = [
-			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'], $info['view']),
+			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'] ?? false, $info['view']),
 			'source'		=> '',
 			'mimeType'		=> 'application/octet-stream',
 			'isMimeTypeIcon' => true,
@@ -395,7 +395,7 @@ class APIv2 extends OCSController {
 	protected function getPreviewFromPath(int $fileId, string $filePath, array $info): array {
 		$mimeType = $info['is_dir'] ? 'dir' : $this->mimeTypeDetector->detectPath($filePath);
 		return [
-			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'], $info['view']),
+			'link'			=> $this->getPreviewLink($info['path'], $info['is_dir'] ?? false, $info['view']),
 			'source'		=> $this->getPreviewPathFromMimeType($mimeType),
 			'mimeType'		=> $mimeType,
 			'isMimeTypeIcon' => true,

--- a/lib/ViewInfoCache.php
+++ b/lib/ViewInfoCache.php
@@ -87,7 +87,7 @@ class ViewInfoCache {
 		$this->cachePath[$user][$path] = [
 			'path'		=> $path,
 			'exists'	=> $exists,
-			'is_dir'	=> $exists ? $this->view->is_dir($path) : false,
+			'is_dir'	=> $exists ? (bool)$this->view->is_dir($path) : false,
 			'view'		=> '',
 		];
 
@@ -128,7 +128,7 @@ class ViewInfoCache {
 				$cache = [
 					'path'		=> substr($path, strlen('/files')),
 					'exists'	=> true,
-					'is_dir'	=> $this->view->is_dir($path),
+					'is_dir'	=> (bool)$this->view->is_dir($path),
 					'view'		=> 'trashbin',
 				];
 			} catch (NotFoundException $e) {


### PR DESCRIPTION
if you set blacklisted_files in your config like

````
'blacklisted_files' => [
    '.htaccess',
    'Thumbs.db',
    'thumbs.db',
],
````

than is the `is_dir` parameter null but the `getPreviewLink` method require a bool, so it generate a error and the activity page hangs.