### PR TITLE
Add Calendar event proper formatting

### DIFF
--- a/js/richObjectStringParser.js
+++ b/js/richObjectStringParser.js
@@ -69,6 +69,9 @@
 				case 'open-graph':
 					return OCA.Activity.Templates.openGraph(parameter).trim("\n");
 
+				case 'calendar-event':
+					return OCA.Activity.Templates.calendarEvent(parameter).trim("\n");
+
 				case 'user':
 					if (_.isUndefined(parameter.server)) {
 						return OCA.Activity.Templates.userLocal(parameter).trim("\n");

--- a/js/templates.js
+++ b/js/templates.js
@@ -51,6 +51,36 @@ templates['activitytabview_activity'] = template({"1":function(container,depth0,
     + ((stack1 = ((helper = (helper = lookupProperty(helpers,"message") || (depth0 != null ? lookupProperty(depth0,"message") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"message","hash":{},"data":data,"loc":{"start":{"line":9,"column":30},"end":{"line":9,"column":43}}}) : helper))) != null ? stack1 : "")
     + "</div>\n</li>\n";
 },"useData":true});
+templates['calendarEvent'] = template({"1":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=container.hooks.helperMissing, alias3="function", alias4=container.escapeExpression, lookupProperty = container.lookupProperty || function(parent, propertyName) {
+        if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
+          return parent[propertyName];
+        }
+        return undefined
+    };
+
+  return "<a class=\"calendar-event\" href=\""
+    + alias4(((helper = (helper = lookupProperty(helpers,"link") || (depth0 != null ? lookupProperty(depth0,"link") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"link","hash":{},"data":data,"loc":{"start":{"line":1,"column":44},"end":{"line":1,"column":52}}}) : helper)))
+    + "\" title=\""
+    + alias4(((helper = (helper = lookupProperty(helpers,"title") || (depth0 != null ? lookupProperty(depth0,"title") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"title","hash":{},"data":data,"loc":{"start":{"line":1,"column":61},"end":{"line":1,"column":70}}}) : helper)))
+    + "\">";
+},"3":function(container,depth0,helpers,partials,data) {
+    return "</a>";
+},"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), lookupProperty = container.lookupProperty || function(parent, propertyName) {
+        if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
+          return parent[propertyName];
+        }
+        return undefined
+    };
+
+  return ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"link") : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":1,"column":0},"end":{"line":1,"column":79}}})) != null ? stack1 : "")
+    + "<strong>"
+    + container.escapeExpression(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : container.hooks.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":1,"column":87},"end":{"line":1,"column":95}}}) : helper)))
+    + "</strong>"
+    + ((stack1 = lookupProperty(helpers,"if").call(alias1,(depth0 != null ? lookupProperty(depth0,"link") : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data,"loc":{"start":{"line":1,"column":104},"end":{"line":1,"column":127}}})) != null ? stack1 : "")
+    + "\n";
+},"useData":true});
 templates['email'] = template({"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=container.hooks.helperMissing, alias3="function", alias4=container.escapeExpression, lookupProperty = container.lookupProperty || function(parent, propertyName) {
         if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {

--- a/js/templates/calendarEvent.handlebars
+++ b/js/templates/calendarEvent.handlebars
@@ -1,0 +1,1 @@
+{{#if link}}<a class="calendar-event" href="{{link}}" title="{{title}}">{{/if}}<strong>{{name}}</strong>{{#if link}}</a>{{/if}}


### PR DESCRIPTION
See https://github.com/nextcloud/server/pull/19039 first

Without this, links to calendar events are not properly formatted (the last last item has got a link on "test").
I don't know much the Activity app so there's probably an easier way to do this.

| Before | After |
|:---------:|:------:|
|![Screenshot_2020-01-21 Activity - Nextcloud](https://user-images.githubusercontent.com/2197836/72792891-06519100-3c3a-11ea-92d2-34212db4e115.png)|![Screenshot_2020-01-21 Activity - Nextcloud- 2](https://user-images.githubusercontent.com/2197836/72792892-06519100-3c3a-11ea-8289-b9c3f4e7bb8c.png)|
