### PR TITLE
Skip notifications for users with invalid email address.

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -325,6 +325,11 @@ class MailQueueHandler {
 			return true;
 		}
 
+		if (!$this->mailer->validateMailAddress($email)) {
+			$this->logger->warning('Notification for user "{user}" not sent because the email address "{email}" is invalid.', ['user' => $userName, 'email' => $email]);
+			return true;
+		}
+
 		list($mailData, $skippedCount) = $this->getItemsForUser($userName, $maxTime);
 
 		$l = $this->getLanguage($lang);

--- a/tests/MailQueueHandlerTest.php
+++ b/tests/MailQueueHandlerTest.php
@@ -242,6 +242,10 @@ class MailQueueHandlerTest extends TestCase {
 		$this->mailer->expects($this->once())
 			->method('createEMailTemplate')
 			->willReturn($template);
+		$this->mailer->expects($this->once())
+			->method('validateMailAddress')
+			->with($email)
+			->willReturn(true);
 
 		$template->expects($this->once())
 			->method('addHeader');


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/20294 https://github.com/nextcloud/server/issues/15600

How to test:

- Have Alice (email: alice@nextcloud.test) and Bob (email: bob).
- Both are members of group Test
- Share a folder to group Test
- Run `occ activity:send-mails`
- We are able to send the notification for Alice but for Bob it fails with something like

![image](https://user-images.githubusercontent.com/3902676/78457805-30e5ae80-76ad-11ea-86e0-57a66e367ce0.png)

- Run `occ activity:send-mails` again
- See the notification for Alice is sent a second time

The faulty code is actual at https://github.com/nextcloud/server/blob/1a9330cd69631ef12b71239c4f98836e09e021ea/lib/private/Mail/Message.php#L82-L83. We might fix that by just deleting `Message::convertAddresses` and `Mailer::convertEmail` method because SwiftMailer supports IDN nowdays.



