### PR TITLE
Fix grouped settings

### DIFF
--- a/css/settings.scss
+++ b/css/settings.scss
@@ -9,7 +9,7 @@ table.activitysettings th.small {
 
 table.activitysettings th.group-header {
 	font-size: 1.3em;
-	color: $color-black;
+	color: var(--color-main-text);
 	padding: 0.5em;
 }
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -104,6 +104,12 @@ class Admin implements ISettings {
 			);
 		}
 
+		if (isset($activityGroups['other'])) {
+			$otherActivities = $activityGroups['other'];
+			unset($activityGroups['other']);
+			$activityGroups['other'] = $otherActivities;
+		}
+
 		$settingBatchTime = UserSettings::EMAIL_SEND_HOURLY;
 		$currentSetting = (int) $this->userSettings->getConfigSetting('setting', 'batchtime');
 		if ($currentSetting === 3600 * 24 * 7) {
@@ -136,7 +142,7 @@ class Admin implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'notification';
+		return 'activity';
 	}
 
 	/**

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -61,7 +61,7 @@ class AdminSection implements IIconSection {
 	 * @since 9.1
 	 */
 	public function getID() {
-		return 'notification';
+		return 'activity';
 	}
 
 	/**
@@ -72,7 +72,7 @@ class AdminSection implements IIconSection {
 	 * @since 9.1
 	 */
 	public function getName() {
-		return $this->l->t('Notifications');
+		return $this->l->t('Activity');
 	}
 
 	/**

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -117,6 +117,12 @@ class Personal implements ISettings {
 			);
 		}
 
+		if (isset($activityGroups['other'])) {
+			$otherActivities = $activityGroups['other'];
+			unset($activityGroups['other']);
+			$activityGroups['other'] = $otherActivities;
+		}
+
 		$settingBatchTime = UserSettings::EMAIL_SEND_HOURLY;
 		$currentSetting = (int) $this->userSettings->getUserSetting($this->user, 'setting', 'batchtime');
 		if ($currentSetting === 3600 * 24 * 7) {
@@ -159,7 +165,7 @@ class Personal implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'notification';
+		return 'activity';
 	}
 
 	/**

--- a/lib/Settings/PersonalSection.php
+++ b/lib/Settings/PersonalSection.php
@@ -61,7 +61,7 @@ class PersonalSection implements IIconSection {
 	 * @since 9.1
 	 */
 	public function getID() {
-		return 'notification';
+		return 'activity';
 	}
 
 	/**
@@ -72,7 +72,7 @@ class PersonalSection implements IIconSection {
 	 * @since 9.1
 	 */
 	public function getName() {
-		return $this->l->t('Notifications');
+		return $this->l->t('Activity');
 	}
 
 	/**


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto von 2020-08-18 14-37-35](https://user-images.githubusercontent.com/213943/90513776-74bee900-e160-11ea-81d1-f44b37c95583.png) | ![Bildschirmfoto von 2020-08-18 14-37-09](https://user-images.githubusercontent.com/213943/90513798-7e485100-e160-11ea-913f-7ac125da51dc.png)

Follow up to #477 
* Readable header color instead of forced black
* Defined settings groups before "others"