### PR TITLE
fix digest activity count not limiting to own activity correctly.

### DIFF
--- a/lib/DigestSender.php
+++ b/lib/DigestSender.php
@@ -136,7 +136,7 @@ class DigestSender {
 			return;
 		}
 
-		['count' => $count, 'max' => $lastActivityId] = $this->data->getActivitySince($uid, $lastSend, false);
+		['count' => $count, 'max' => $lastActivityId] = $this->data->getActivitySince($uid, $lastSend, true);
 		$count = (int) $count;
 		$lastActivityId = (int) $lastActivityId;
 		if ($count === 0) {


### PR DESCRIPTION
Boolean logic is hard 🙈 .

Fixes sending activity digest mails when you only have your own activity