### PR TITLE
Hide stream / disable notifications for specific groups

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -32,5 +32,14 @@ $(document).ready(function() {
 			'activity', 'enable_email',
 			$(this).attr('checked') === 'checked' ? 'yes' : 'no'
 		);
-	})
+	});
+
+	$('#activity_system_users_group_list').each(function (index, element) {
+		OC.Settings.setupGroupsSelect($(element));
+		$(element).change(function(ev) {
+			var groups = ev.val || [];
+			groups = JSON.stringify(groups);
+			OCP.AppConfig.setValue('activity', $(this).attr('name'), groups);
+		});
+	});
 });

--- a/js/settings.js
+++ b/js/settings.js
@@ -27,3 +27,99 @@ $(document).ready(function() {
 		saveSettings();
 	});
 });
+
+OC.Settings = OC.Settings || {};
+OC.Settings = _.extend(OC.Settings, {
+
+	_cachedGroups: null,
+
+	/**
+	 * Setup selection box for group selection.
+	 *
+	 * Values need to be separated by a pipe "|" character.
+	 * (mostly because a comma is more likely to be used
+	 * for groups)
+	 *
+	 * @param $elements jQuery element (hidden input) to setup select2 on
+	 * @param {Array} [extraOptions] extra options hash to pass to select2
+	 * @param {Array} [options] extra options
+	 * @param {Array} [options.excludeAdmins=false] flag whether to exclude admin groups
+	 */
+	setupGroupsSelect: function($elements, extraOptions, options) {
+		var self = this;
+		options = options || {};
+		if ($elements.length > 0) {
+			// Let's load the data and THEN init our select
+			$.ajax({
+				url: OC.linkToOCS('cloud/groups', 2) + 'details',
+				dataType: 'json',
+				success: function(data) {
+					var results = [];
+
+					if (data.ocs.data.groups && data.ocs.data.groups.length > 0) {
+
+						data.ocs.data.groups.forEach(function(group) {
+							if (!options.excludeAdmins || group.id !== 'admin') {
+								results.push({ id: group.id, displayname: group.displayname });
+							}
+						})
+
+						// note: settings are saved through a "change" event registered
+						// on all input fields
+						$elements.select2(_.extend({
+							placeholder: t('core', 'Groups'),
+							allowClear: true,
+							multiple: true,
+							toggleSelect: true,
+							separator: '|',
+							data: { results: results, text: 'displayname' },
+							initSelection: function(element, callback) {
+								var groups = $(element).val();
+								var selection;
+								if (groups && results.length > 0) {
+									selection = _.map(_.filter((groups || []).split('|').sort(), function(groupId) {
+										return results.find(function(group) {
+											return group.id === groupId
+										}) !== undefined
+									}), function(groupId) {
+										return {
+											id: groupId,
+											displayname: results.find(function(group) {
+												return group.id === groupId
+											}).displayname
+										}
+									})
+								} else if (groups) {
+									selection = _.map((groups || []).split('|').sort(), function(groupId) {
+										return {
+											id: groupId,
+											displayname: groupId
+										};
+									});
+								}
+								callback(selection);
+							},
+							formatResult: function(element) {
+								return escapeHTML(element.displayname);
+							},
+							formatSelection: function(element) {
+								return escapeHTML(element.displayname);
+							},
+							escapeMarkup: function(m) {
+								// prevent double markup escape
+								return m;
+							}
+						}, extraOptions || {}));
+					} else {
+						OC.Notification.show(t('settings', 'Group list is empty'), { type: 'error' });
+						console.log(data);
+					}
+				},
+				error: function(data) {
+					OC.Notification.show(t('settings', 'Unable to retrieve the group list'), { type: 'error' });
+					console.log(data);
+				}
+			});
+		}
+	}
+});

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -56,6 +56,7 @@ OC.L10N.register(
     "Stream" : "Stream",
     "Send activity emails" : "E-Mails zu Aktivitäten senden",
     "Configure the default activity settings for new users." : "Nehme die Voreinstellungen der Aktivitäten für neue Benutzer vor.",
+	"Define groups, such as system users groups, whose activities will not be displayed (except for themselves)." : "Definiere Gruppen, z. B. Systembenutzergruppen, deren Aktivitäten nicht angezeigt werden (außer für sich selbst).",
     "List your own actions in the stream" : "Deine eigenen Aktivitäten im Stream auflisten",
     "Notify about your own actions via email" : "Über Deine eigenen Aktivitäten via E-Mail benachrichtigen",
     "Send emails:" : "Sende E-Mails:",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -54,6 +54,7 @@
     "Stream" : "Stream",
     "Send activity emails" : "E-Mails zu Aktivitäten senden",
     "Configure the default activity settings for new users." : "Nehme die Voreinstellungen der Aktivitäten für neue Benutzer vor.",
+	"Define groups, such as system users groups, whose activities will not be displayed (except for themselves)." : "Definiere Gruppen, z. B. Systembenutzergruppen, deren Aktivitäten nicht angezeigt werden (außer für sich selbst).",
     "List your own actions in the stream" : "Deine eigenen Aktivitäten im Stream auflisten",
     "Notify about your own actions via email" : "Über Deine eigenen Aktivitäten via E-Mail benachrichtigen",
     "Send emails:" : "Sende E-Mails:",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -56,6 +56,7 @@ OC.L10N.register(
     "Stream" : "Stream",
     "Send activity emails" : "E-Mails zu Aktivitäten senden",
     "Configure the default activity settings for new users." : "Nehmen Sie  die Voreinstellungen der Aktivitäten für neue Benutzer vor.",
+	"Define groups, such as system users groups, whose activities will not be displayed (except for themselves)." : "Definiere Gruppen, z. B. Systembenutzergruppen, deren Aktivitäten nicht angezeigt werden (außer für sich selbst).",
     "List your own actions in the stream" : "Ihre eigenen Aktivitäten im Stream auflisten",
     "Notify about your own actions via email" : "Über Ihre eigenen Aktivitäten via E-Mail benachrichtigen",
     "Send emails:" : "E-Mails senden:",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -54,6 +54,7 @@
     "Stream" : "Stream",
     "Send activity emails" : "E-Mails zu Aktivitäten senden",
     "Configure the default activity settings for new users." : "Nehmen Sie  die Voreinstellungen der Aktivitäten für neue Benutzer vor.",
+	"Define groups, such as system users groups, whose activities will not be displayed (except for themselves)." : "Definiere Gruppen, z. B. Systembenutzergruppen, deren Aktivitäten nicht angezeigt werden (außer für sich selbst).",
     "List your own actions in the stream" : "Ihre eigenen Aktivitäten im Stream auflisten",
     "Notify about your own actions via email" : "Über Ihre eigenen Aktivitäten via E-Mail benachrichtigen",
     "Send emails:" : "E-Mails senden:",

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -120,6 +120,10 @@ class Admin implements ISettings {
 			$settingBatchTime = UserSettings::EMAIL_SEND_ASAP;
 		}
 
+		$systemUsersGroups = $this->config->getAppValue('activity', 'activity_system_users_group_list', '');
+		$systemUsersGroupList = !is_null(json_decode($systemUsersGroups))
+			? implode('|', json_decode($systemUsersGroups, true)) : '';
+
 		return new TemplateResponse('activity', 'settings/admin', [
 			'setting'			=> 'admin',
 			'activityGroups'		=> $activityGroups,
@@ -135,6 +139,8 @@ class Admin implements ISettings {
 				IExtension::METHOD_MAIL => $this->l10n->t('Mail'),
 				IExtension::METHOD_NOTIFICATION => $this->l10n->t('Push'),
 			],
+
+			'system_users_group_list' => $systemUsersGroupList,
 		], 'blank');
 	}
 

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -38,7 +38,7 @@ style('activity', 'settings');
 	<p class="settings-hint indent">
 		<?php p($l->t('Define groups, such as system users groups, whose activities will not be displayed (except for themselves).')); ?>
 		<br />
-		<input name="activity_system_users_group_list" id="activity_system_users_group_list" value="<?php p($_['systemGroupList']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
+		<input name="activity_system_users_group_list" id="activity_system_users_group_list" value="<?php p($_['system_users_group_list']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
 	</p>
 
 </div>

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -31,6 +31,15 @@ style('activity', 'settings');
 	<input id="activity_email_enabled" name="activity_email_enabled" type="checkbox" class="checkbox"
 		   value="1" <?php if ($_['email_enabled']) { print_unescaped('checked="checked"'); } ?> />
 	<label for="activity_email_enabled"><?php p($l->t('Enable notification emails')); ?></label>
+	<br />
+	<br />
+	<br />
+
+	<p class="settings-hint indent">
+		<?php p($l->t('Define groups, such as system users groups, whose activities will not be displayed (except for themselves).')); ?>
+		<br />
+		<input name="activity_system_users_group_list" id="activity_system_users_group_list" value="<?php p($_['systemGroupList']) ?>" style="width: 400px" class="noJSAutoUpdate"/>
+	</p>
 
 </div>
 


### PR DESCRIPTION
This PR allows you to define groups, such as system users groups, whose activities will not be displayed in the stream, except for themselves, and no email notifications will be send out.