### PR TITLE
getUsersFavoritingObject is moved to the manager

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -26,7 +26,6 @@ namespace OCA\Activity;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
-use OC\Tags;
 use OCA\Activity\BackgroundJob\RemoteActivity;
 use OCA\Activity\Extension\Files;
 use OCA\Activity\Extension\Files_Sharing;
@@ -105,7 +104,7 @@ class FilesHooks {
 	protected $oldParentId;
 	/** @var NotificationGenerator */
 	protected $notificationGenerator;
-	/** @var Tags */
+	/** @var ITagManager */
 	protected $tagManager;
 
 	public function __construct(
@@ -139,7 +138,7 @@ class FilesHooks {
 		$this->userMountCache = $userMountCache;
 		$this->config = $config;
 		$this->notificationGenerator = $notificationGenerator;
-		$this->tagManager = $tagManager->load('files');
+		$this->tagManager = $tagManager;
 	}
 
 	/**

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -26,6 +26,7 @@ namespace OCA\Activity;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OC\TagManager;
 use OCA\Activity\BackgroundJob\RemoteActivity;
 use OCA\Activity\Extension\Files;
 use OCA\Activity\Extension\Files_Sharing;
@@ -104,7 +105,7 @@ class FilesHooks {
 	protected $oldParentId;
 	/** @var NotificationGenerator */
 	protected $notificationGenerator;
-	/** @var ITagManager */
+	/** @var ITagManager|TagManager */
 	protected $tagManager;
 
 	public function __construct(
@@ -189,7 +190,7 @@ class FilesHooks {
 		$filteredEmailUsers = $this->userSettings->filterUsersBySetting($users, 'email', Files::TYPE_FILE_CHANGED);
 		$filteredNotificationUsers = $this->userSettings->filterUsersBySetting($users, 'notification', Files::TYPE_FILE_CHANGED);
 
-		$favoriteUsers = $this->tagManager->getUsersFavoritingObject($fileId);
+		$favoriteUsers = $this->tagManager->getUsersFavoritingObject('files', $fileId);
 		if (!empty($favoriteUsers)) {
 			$favoriteUsers = array_intersect($users, $favoriteUsers);
 			if (!empty($favoriteUsers)) {


### PR DESCRIPTION
Fix #499 

- [x] Requires: https://github.com/nextcloud/server/pull/23184
Ref https://sentry.io/organizations/nextcloud-gmbh/issues/1927876255