### PR TITLE
Fix the deletion error in public links

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -190,16 +190,20 @@ class FilesHooks {
 		$filteredEmailUsers = $this->userSettings->filterUsersBySetting($users, 'email', Files::TYPE_FILE_CHANGED);
 		$filteredNotificationUsers = $this->userSettings->filterUsersBySetting($users, 'notification', Files::TYPE_FILE_CHANGED);
 
-		$favoriteUsers = $this->tagManager->getUsersFavoritingObject($fileId);
-		if (!empty($favoriteUsers)) {
-			$favoriteUsers = array_intersect($users, $favoriteUsers);
+		if ($this->tagManager !== null) {
+			$favoriteUsers = $this->tagManager->getUsersFavoritingObject($fileId);
 			if (!empty($favoriteUsers)) {
-				$filteredEmailUsers = array_merge($filteredEmailUsers, $this->userSettings->filterUsersBySetting($favoriteUsers, 'email', Files::TYPE_FAVORITE_CHANGED));
-				$filteredNotificationUsers = array_merge($filteredNotificationUsers, $this->userSettings->filterUsersBySetting($favoriteUsers, 'notification', Files::TYPE_FAVORITE_CHANGED));
+				$favoriteUsers = array_intersect($users, $favoriteUsers);
+				if (!empty($favoriteUsers)) {
+					$filteredEmailUsers = array_merge($filteredEmailUsers, $this->userSettings->filterUsersBySetting($favoriteUsers, 'email', Files::TYPE_FAVORITE_CHANGED));
+					$filteredNotificationUsers = array_merge($filteredNotificationUsers, $this->userSettings->filterUsersBySetting($favoriteUsers, 'notification', Files::TYPE_FAVORITE_CHANGED));
+				}
 			}
+
+			return [$filteredEmailUsers, $filteredNotificationUsers];
 		}
 
-		return [$filteredEmailUsers, $filteredNotificationUsers];
+		return [[null], [null]];
 	}
 
 	/**

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -143,7 +143,7 @@ class FilesHooksTest extends TestCase {
 					$this->notificationGenerator,
 					$this->tagManager
 				])
-				->onlyMethods($mockedMethods)
+				->setMethods($mockedMethods)
 				->getMock();
 		}
 
@@ -891,7 +891,7 @@ class FilesHooksTest extends TestCase {
 		if ($validMountPoint) {
 			$storage = $this->getMockBuilder(SharedStorage::class)
 				->disableOriginalConstructor()
-				->onlyMethods([
+				->setMethods([
 					'instanceOfStorage',
 					'getSharedFrom',
 				])
@@ -1065,5 +1065,12 @@ class FilesHooksTest extends TestCase {
 			->with($event, $this->anything());
 
 		self::invokePrivate($this->filesHooks, 'addNotificationsForUser', [$user, $subject, $parameter, $fileId, $path, $isFile, $email, $notification, $type]);
+	}
+
+	public function testPublicLinkActivity() {
+		$fileHooks = $this->getFilesHooks();
+		$result = $this->invokePrivate($fileHooks, 'getFileChangeActivitySettings', [12, ['user']]);
+
+		$this->assertEquals([null, null], $result);
 	}
 }


### PR DESCRIPTION
When user tries to delete the files in a public
link, the files don't get deleted. The tagManager
gets null and there was no check to handle this.
Added check for this.

Signed-off-by: Sujith Haridasan <sujith.h@gmail.com>