### PR TITLE
Fix the comments added to the activity table

### DIFF
--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -67,10 +67,7 @@ class Consumer implements IConsumer {
 		$emailSetting = $this->userSettings->getUserSetting($event->getAffectedUser(), 'email', $event->getType());
 		$emailSetting = ($emailSetting) ? $this->userSettings->getUserSetting($event->getAffectedUser(), 'setting', 'batchtime') : false;
 
-		// Add activity to stream
-		if (!$selfAction) {
-			$activityId = $this->data->send($event);
-		}
+		$activityId = $this->data->send($event);
 
 		if (!$selfAction && $notificationSetting && $activityId) {
 			$this->notificationGenerator->sendNotificationForEvent($event, $activityId);

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -144,7 +144,7 @@ class ConsumerTest extends TestCase {
 	 * @param string $subject
 	 * @param array|false $expected
 	 */
-	public function testReceiveStream(string $type, string $author, string $affectedUser, string $subject, $expected): void {
+	public function testReceiveStream(string $type, string $author, string $affectedUser, string $subject): void {
 		$consumer = new Consumer($this->data, $this->activityManager, $this->userSettings, $this->notificationGenerator);
 		$event = \OC::$server->getActivityManager()->generateEvent();
 		$event->setApp('test')
@@ -158,13 +158,8 @@ class ConsumerTest extends TestCase {
 			->setLink('link');
 		$this->deleteTestActivities();
 
-		if ($author === $affectedUser) {
-			$this->data->expects($this->never())
-				->method('send');
-		} else {
-			$this->data->expects($this->once())
-				->method('send');
-		}
+		$this->data->expects($this->once())
+			->method('send');
 
 		$consumer->receive($event);
 	}


### PR DESCRIPTION
When user adds comments to a file, the activity
notifications were not updated. This change does
fix the issue.

Signed-off-by: Sujith Haridasan <sujith.h@gmail.com>