### PR TITLE
Don't break sending emails with non-string parameters

### DIFF
--- a/lib/DigestSender.php
+++ b/lib/DigestSender.php
@@ -231,9 +231,9 @@ class DigestSender {
 			$placeholders[] = '{' . $placeholder . '}';
 
 			if ($parameter['type'] === 'file') {
-				$replacement = $parameter['path'];
+				$replacement = (string) $parameter['path'];
 			} else {
-				$replacement = $parameter['name'];
+				$replacement = (string) $parameter['name'];
 			}
 
 			if (isset($parameter['link'])) {

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -425,9 +425,9 @@ class MailQueueHandler {
 			$placeholders[] = '{' . $placeholder . '}';
 
 			if ($parameter['type'] === 'file') {
-				$replacement = $parameter['path'];
+				$replacement = (string) $parameter['path'];
 			} else {
-				$replacement = $parameter['name'];
+				$replacement = (string) $parameter['name'];
 			}
 
 			if (isset($parameter['link'])) {


### PR DESCRIPTION
A workaround for https://github.com/nextcloud/server/issues/24434
The problem is int is invalid for names of rich object strings and might actually break the mobile clients on parsing them.
So finding out which app it actually is and turn it to a string there is the better way.