### PR TITLE
Fix 'Daily activity summary' email subject translation

### DIFF
--- a/lib/DigestSender.php
+++ b/lib/DigestSender.php
@@ -178,7 +178,7 @@ class DigestSender {
 			'activityEvents' => $activities,
 			'skippedCount' => $skippedCount,
 		]);
-		$template->setSubject($l10n->t('Daily activity summary for ' . $this->defaults->getName()));
+		$template->setSubject($l10n->t('Daily activity summary for %s', $this->defaults->getName()));
 		$template->addHeader();
 
 		foreach ($activities as $event) {


### PR DESCRIPTION
It was never translated.