### PR TITLE
Ensure link names are unique for accessibility, thanks @nickvergessen, fix #575

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -253,7 +253,7 @@ $(function(){
 				for (var i = 0; i < activity.previews.length; i++) {
 					var preview = activity.previews[i];
 					content += ((preview.link) ? '<a href="' + preview.link + '">' + "\n" : '')
-						+ '<img class="preview' + ((preview.isMimeTypeIcon) ? ' preview-mimetype-icon' : '') + '" src="' + preview.source + '" alt="' + t('activity', 'Open file') + '" />' + "\n"
+						+ '<img class="preview' + ((preview.isMimeTypeIcon) ? ' preview-mimetype-icon' : '') + '" src="' + preview.source + '" alt="' + t('activity', 'Open {filename}', preview) + '" />' + "\n"
 						+ ((preview.link) ? '</a>' + "\n" : '')
 				}
 				content += '</div>';

--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -402,6 +402,7 @@ class APIv2Controller extends OCSController {
 			'isMimeTypeIcon' => true,
 			'fileId' => $fileId,
 			'view' => $info['view'] ?: 'files',
+			'filename' => basename($filePath),
 		];
 	}
 

--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -363,6 +363,7 @@ class APIv2Controller extends OCSController {
 			'isMimeTypeIcon' => true,
 			'fileId' => $fileId,
 			'view' => $info['view'] ?: 'files',
+			'filename' => basename($filePath),
 		];
 
 		// show a preview image if the file still exists

--- a/tests/Controller/APIv2ControllerTest.php
+++ b/tests/Controller/APIv2ControllerTest.php
@@ -765,6 +765,7 @@ class APIv2ControllerTest extends TestCase {
 					'isMimeTypeIcon' => $isMimeTypeIcon,
 					'fileId' => $fileId,
 					'view' => 'files',
+					'filename' => basename($path),
 				]);
 		}
 
@@ -775,6 +776,7 @@ class APIv2ControllerTest extends TestCase {
 			'isMimeTypeIcon' => $isMimeTypeIcon,
 			'fileId' => $fileId,
 			'view' => 'files',
+			'filename' => basename($path),
 		], self::invokePrivate($controller, 'getPreview', [$author, $fileId, $path]));
 	}
 
@@ -820,6 +822,7 @@ class APIv2ControllerTest extends TestCase {
 				'isMimeTypeIcon' => true,
 				'fileId' => $fileId,
 				'view' => $view ?: 'files',
+				'filename' => basename($filePath),
 			],
 			self::invokePrivate($controller, 'getPreviewFromPath', [$fileId, $filePath, ['path' => $filePath, 'is_dir' => $isDir, 'view' => $view]])
 		);


### PR DESCRIPTION
Before, there were a lot of duplicate links on the page all saying "Open file", which makes it a problem for screen readers:
![image](https://user-images.githubusercontent.com/925062/114581066-b23c2d80-9c7f-11eb-9231-28979559b472.png)

This is now fixed by changing the link to say "Open `filename`" stating the actual filename.

Since the links are already there in text form directly above, in the future we could also remove the duplicate linked images from screenreader flow by using divs for them and triggering the link via Javascript.