### PR TITLE
Only call getCloudId if needed

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -229,7 +229,9 @@ class FilesHooks {
 
 		$accessList = $this->getUserPathsFromPath($filePath, $uidOwner);
 
-		$this->generateRemoteActivity($accessList['remotes'], $activityType, time(), $this->currentUser->getCloudId(), $accessList['ownerPath']);
+		if (!empty($accessList['remotes'])) {
+			$this->generateRemoteActivity($accessList['remotes'], $activityType, time(), $this->currentUser->getCloudId(), $accessList['ownerPath']);
+		}
 
 		if ($this->config->getSystemValueBool('activity_use_cached_mountpoints', false)) {
 			$mountsForFile = $this->userMountCache->getMountsForFileId($fileId);


### PR DESCRIPTION
[getCloudId can be expensive](https://github.com/nextcloud/server/blob/master/lib/private/Federation/CloudIdManager.php#L84-L120), especially on large instances since curently the contacts manager is called to search for the cloud id which may lead to slow queries as it searches the oc_card_properties table with a LIKE on every file action:

SELECT DISTINCT `cp`.`cardid` FROM `oc_cards_properties` `cp` WHERE (`cp`.`addressbookid` = N) AND (`cp`.`name` = N) AND (`cp`.`value`  COLLATE utfNmbN_general_ci LIKE N);

This PR ensures that we only call this if really needed for dispatching remote activities. A separate enhancement to avoid this search for local users is following for the server.