### PR TITLE
Add rebase command from organization workflow template

### DIFF
--- a/.github/workflows/command-rebase.yml
+++ b/.github/workflows/command-rebase.yml
@@ -1,0 +1,46 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Rebase command
+
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+
+    # On pull requests and if the comment starts with `/rebase`
+    if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/rebase')
+
+    steps:
+      - name: Add reaction on start
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reaction-type: "+1"
+
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMAND_BOT_PAT }}
+
+      - name: Add reaction on failure
+        uses: peter-evans/create-or-update-comment@v1
+        if: failure()
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          repository: ${{ github.event.repository.full_name }}
+          comment-id: ${{ github.event.comment.id }}
+          reaction-type: "-1"


### PR DESCRIPTION
This makes it easier to rebase PRs by using the existing GitHub Actions workflow to provide a `/rebase` command.