### PR TITLE
Fix reenabling the email option

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
 	$('#activity_email_enabled').on('change', function() {
 		OCP.AppConfig.setValue(
 			'activity', 'enable_email',
-			$(this).prop('checked') === 'checked' ? 'yes' : 'no'
+			$(this).prop('checked') ? 'yes' : 'no'
 		);
 	})
 });


### PR DESCRIPTION
Fix #609 

### Steps
1. Go to admin settings
2. Disable the notification email option
3. Reload the page and check if the state is consistent
4. Enable the notification email option again
5. Reload the page and check if the state is consistent