### PR TITLE
fix link to activity section

### DIFF
--- a/lib/Navigation.php
+++ b/lib/Navigation.php
@@ -135,6 +135,6 @@ class Navigation {
 	 * @return string
 	 */
 	protected function getPersonalSettingsLink() {
-		return $this->URLGenerator->linkToRouteAbsolute('settings.PersonalSettings.index', ['section' => 'activity']);
+		return $this->URLGenerator->linkToRouteAbsolute('settings.PersonalSettings.index', ['section' => 'notifications']);
 	}
 }


### PR DESCRIPTION
Just noticed on c.nc.c

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e ACTIVITY_BRANCH=fix/noid/fix-activity-link \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.130 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>