### PR TITLE
Pass activity link to notification

### DIFF
--- a/lib/NotificationGenerator.php
+++ b/lib/NotificationGenerator.php
@@ -74,6 +74,10 @@ class NotificationGenerator implements INotifier {
 			$notification->setMessage($event->getMessage());
 		}
 
+		if ($event->getLink()) {
+			$notification->setLink($event->getLink());
+		}
+
 		return $notification;
 	}
 


### PR DESCRIPTION
Notifications generated from activity entries should take over the link that the original activity entry has set as reported in https://github.com/nextcloud/deck/issues/3431