### PR TITLE
Fix group move/rename activities

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -350,6 +350,7 @@ class FilesHooks {
 			return;
 		}
 		$this->oldAccessList = $this->getUserPathsFromPath($this->oldParentPath, $this->oldParentOwner);
+		$this->oldAccessList['users'] = $this->getAffectedUsers($this->oldAccessList['users'], $this->oldParentId);
 	}
 
 
@@ -409,7 +410,7 @@ class FilesHooks {
 		}
 		$this->generateRemoteActivity($renameRemotes, Files::TYPE_FILE_CHANGED, time(), $this->currentUser->getCloudId());
 
-		$affectedUsers = $accessList['users'];
+		$affectedUsers = $this->getAffectedUsers($accessList['users'], $fileId);
 		[$filteredEmailUsers, $filteredNotificationUsers] = $this->getFileChangeActivitySettings($fileId, array_keys($affectedUsers));
 
 		foreach ($affectedUsers as $user => $path) {
@@ -456,7 +457,7 @@ class FilesHooks {
 			return;
 		}
 		$accessList = $this->getUserPathsFromPath($parentPath, $parentOwner);
-		$affectedUsers = $accessList['users'];
+		$affectedUsers = $this->getAffectedUsers($accessList['users'], $fileId);
 		$oldUsers = $this->oldAccessList['users'];
 
 		$beforeUsers = array_keys($oldUsers);


### PR DESCRIPTION
This is a respin of #500. The code is essentially the same, but with a few small style fixes and rebased and tested on master of server, activities app and groupfolders app.

This still doesn't cover the handling of sharing events for other groupfolder users. So it only partly solves https://github.com/nextcloud/groupfolders/issues/1018.

Cc: @chrisfritsche 