### PR TITLE
Run Cypress in more contexts

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,11 @@
 name: Cypress
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - stable*
 
 env:
   APP_NAME: activity


### PR DESCRIPTION
Cypress is currently only run on push on one of this repo's branch. When a contributor opens a PR from one of its fork's branch, the workflow was not run. This PR should fix it.