### PR TITLE
Update activity endpoint type filter URL

### DIFF
--- a/docs/endpoint-v2.md
+++ b/docs/endpoint-v2.md
@@ -24,7 +24,7 @@ GET /ocs/v2.php/apps/activity/api/v2/activity
 With type filter
 
 ```
-GET /ocs/v2.php/apps/activity/api/v2/activity/:filter
+GET /ocs/v2.php/apps/activity/api/v2/activity/filter
 ```
 
 ## Parameters


### PR DESCRIPTION
Using `/:filter` returns 404.  Must use `/filter` without the colon.

Signed-off-by: Aaron Segura <aaron@aaronsegura.com>