### PR TITLE
Fix translation ignore

### DIFF
--- a/.l10nignore
+++ b/.l10nignore
@@ -1,2 +1,2 @@
-js/activity-*
+js/activity-
 js/templates.js


### PR DESCRIPTION
Ref https://github.com/nextcloud/activity/pull/880#issuecomment-1225256826

Current error:
> Those files are ignored:
Array
(
    [0] => js/activity-*
    [1] => js/templates.js
)
/app/js/activity-adminSettings.js:2: warning: Empty msgid.  It is reserved by GNU gettext:
                                              gettext("") returns the header entry with
                                              meta information, not the empty string.


Tested locally and it works now.