### PR TITLE
Do not pass an instance of User where a string is expected

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -416,7 +416,7 @@ class MailQueueHandler {
 		} catch (\Exception $e) {
 			$this->logger->logException($e, [
 				'message' => 'Failed sending activity email to user "{user}"',
-				'user' => $user,
+				'user' => $userName,
 				'app' => 'activity',
 			]);
 			return false;


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/34139

Signed-off-by: Côme Chilliet <come.chilliet@nextcloud.com>