### PR TITLE
Revert "Revert "[stable23] Do not pass an instance of User where a string is expected""

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -407,7 +407,7 @@ class MailQueueHandler {
 		} catch (\Exception $e) {
 			$this->logger->logException($e, [
 				'message' => 'Failed sending activity email to user "{user}"',
-				'user' => $user,
+				'user' => $userName,
 				'app' => 'activity',
 			]);
 			return false;


### PR DESCRIPTION
Reverts nextcloud/activity#1022

It was merged too early – reopening.