### PR TITLE
remove heading slash

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -1288,7 +1288,7 @@ class FilesHooks {
 						continue; // acl are disable
 					}
 
-					$folderPath = $mountPoint->getSourcePath();
+					$folderPath = ltrim($mountPoint->getSourcePath(), '/');
 					$path = substr($fullPath, strlen($mountPoint->getMountPoint()));
 				} catch (\Exception $e) {
 					// in case of issue during the process, we can imagine the user have no access to the file


### PR DESCRIPTION
the hash is not correct if we keep the heading slash on the generated path, starting with `/__groupfolders`, meaning we don't get the correct ACL rules later with `getAllRulesForPaths()`

