### PR TITLE
Adapt test to modern getMount()

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -34,7 +34,6 @@ use OCP\Activity\IManager;
 use OCP\Constants;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\IRootFolder;
-use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
@@ -1128,8 +1127,10 @@ class FilesHooks {
 		 * Get the sharee who shared the item with the currentUser
 		 */
 		$this->view->chroot('/' . $currentOwner . '/files');
-		$mount = $this->view->getMount($path);
-		if (!($mount instanceof IMountPoint)) {
+
+		try {
+			$mount = $this->view->getMount($path);
+		} catch (NotFoundException $ex) {
 			return;
 		}
 

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -922,7 +922,7 @@ class FilesHooksTest extends TestCase {
 			$this->view->expects($this->once())
 				->method('getMount')
 				->with('/path')
-				->willReturn(null);
+				->willThrowException(new \OCP\Files\NotFoundException());
 		}
 
 		self::invokePrivate($filesHooks, 'shareNotificationForOriginalOwners', ['current', 'subject', 'with', 42, 'type']);


### PR DESCRIPTION
`MountManager->getMount()` is now throwing an error instead of returning `null`.

This commit makes sure that we handle properly the cases of un-existing mount.

- https://github.com/nextcloud/server/pull/31431/files#diff-1a9e0726ff3c8a791a887953a207ebb95f3c51bb9fa3fdba365bed61747166c2R118
- https://github.com/nextcloud/server/pull/36836/files#diff-64a02ee1149d33d0747360694c2abf4ef1bdbfc379b4bb40f76c22b5b1fc06d9R203