### PR TITLE
Add more aria attributes to activity-settings button

### DIFF
--- a/templates/stream.app.navigation.php
+++ b/templates/stream.app.navigation.php
@@ -41,7 +41,9 @@
 
 	<div id="app-settings">
 		<div id="app-settings-header">
-			<button class="settings-button" data-apps-slide-toggle="#app-settings-content"><?php p($l->t('Activity settings'));?></button>
+			<button class="settings-button" aria-expanded="false" aria-controls="app-settings-content" aria-label="Activity settings" data-apps-slide-toggle="#app-settings-content">
+				<?php p($l->t('Activity settings'));?>
+			</button>
 		</div>
 
 		<div id="app-settings-content">


### PR DESCRIPTION
- Adds `aria-expanded` as this buttons triggers the expand or collapse of another section
- Add `aria-label` for better support of assitive technologies.

NB: The mechanism to change the state of the `aria-expanded` attribute, leaves out of this repository in https://github.com/nextcloud/server/blob/master/core/src/OC/apps.js

Resolves : https://github.com/nextcloud/activity/issues/1110