### PR TITLE
fix(db): pre- SELECT ids with a LIMIT to control the amount of rows deleted for MySQL

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -59,6 +59,7 @@ use OCP\User\Events\PostLoginEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'activity';
@@ -110,7 +111,8 @@ class Application extends App implements IBootstrap {
 		$context->registerService(Data::class, function (ContainerInterface $c) {
 			return new Data(
 				$c->get(IManager::class),
-				$c->get('ActivityConnectionAdapter')
+				$c->get('ActivityConnectionAdapter'),
+				$c->get(LoggerInterface::class),
 			);
 		});
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
 		<UndefinedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform" />
+				<referencedClass name="Doctrine\DBAL\Platforms\AbstractMySQLPlatform" />
 				<referencedClass name="Doctrine\DBAL\Types\Types" />
 				<referencedClass name="OC" />
 				<referencedClass name="OC\Core\Command\Base" />

--- a/tests/Controller/APIv1ControllerTest.php
+++ b/tests/Controller/APIv1ControllerTest.php
@@ -41,6 +41,7 @@ use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\RichObjectStrings\IValidator;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class APIv1Test
@@ -106,7 +107,8 @@ class APIv1ControllerTest extends TestCase {
 	protected function cleanUp(): void {
 		$data = new Data(
 			$this->createMock(IManager::class),
-			\OC::$server->getDatabaseConnection()
+			\OC::$server->getDatabaseConnection(),
+			$this->createMock(LoggerInterface::class)
 		);
 
 		$this->deleteUser($data, 'activity-api-user1');
@@ -220,7 +222,10 @@ class APIv1ControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn($user);
 
-		$data = new Data($activityManager, \OC::$server->getDatabaseConnection());
+		$data = new Data($activityManager,
+			\OC::$server->getDatabaseConnection(),
+			$this->createMock(LoggerInterface::class)
+		);
 
 		$controller = new APIv1Controller(
 			'activity',

--- a/tests/DataDeleteActivitiesTest.php
+++ b/tests/DataDeleteActivitiesTest.php
@@ -32,7 +32,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\DB\IPreparedStatement;
 use OCP\IConfig;
-use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class DataDeleteActivitiesTest
@@ -74,7 +74,7 @@ class DataDeleteActivitiesTest extends TestCase {
 		$this->data = new Data(
 			$this->createMock(IManager::class),
 			\OC::$server->getDatabaseConnection(),
-			$this->createMock(IUserSession::class)
+			$this->createMock(LoggerInterface::class)
 		);
 	}
 

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -31,6 +31,7 @@ use OCP\IL10N;
 use OCP\IUserSession;
 use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
 
 /**
  * Class DataTest
@@ -54,6 +55,9 @@ class DataTest extends TestCase {
 	/** @var IManager */
 	protected $realActivityManager;
 
+	/** @var NullLogger */
+	protected $logger;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -61,10 +65,12 @@ class DataTest extends TestCase {
 		$activityManager = $this->createMock(IManager::class);
 		$this->dbConnection = \OC::$server->get(IDBConnection::class);
 		$this->realActivityManager = \OC::$server->get(IManager::class);
+		$this->logger = \OC::$server->get(NullLogger::class);
 
 		$this->data = new Data(
 			$activityManager,
-			$this->dbConnection
+			$this->dbConnection,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
Doctrine does not allow LIMITs on DELETE queries:

https://stackoverflow.com/questions/25308171/doctrine-query-delete-with-limit

Thus we need to handle MySQL/MariaDB separately as clustered setups are not going to be able to handle more than 128k rows / 2GB of writes at any one time.

I have set the current LIMIT to 10k but an argument could probably be made to use 20k. We can adjust in the future. I choose this limit to handle clustered setups where wsrep_max_ws_size or wsrep_max_ws_rows is lower than the expected value.

MySQL also doesn't allow LIMITs in IN subqueries.