### PR TITLE
fix: Add stub for files event to fix psalm error

### DIFF
--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -23,8 +23,8 @@
 import { createFolder, goToDir, moveFile, renameFile } from './filesUtils'
 import { addComment, addTag, addToFavorites, createPublicShare, removeFromFavorites, showActivityTab } from './sidebarUtils'
 
-describe('Check activity listing in the sidebar', () => {
-	before(function() {
+describe('Check activity listing in the sidebar', { testIsolation: true }, () => {
+	beforeEach(function() {
 		cy.createRandomUser()
 			.then((user) => {
 				cy.login(user)

--- a/cypress/e2e/sidebarUtils.ts
+++ b/cypress/e2e/sidebarUtils.ts
@@ -20,22 +20,23 @@
  *
  */
 
-import { toggleMenuAction } from "./filesUtils"
+import { toggleMenuAction } from './filesUtils'
 
 function showSidebarForFile(fileName: string) {
 	closeSidebar()
 	toggleMenuAction(fileName)
 	cy.get('[data-cy-files-list-row-action="details"]').click()
-	cy.get('#app-sidebar-vue').contains('Activity').click()
+	cy.get('#app-sidebar-vue').should('be.visible')
 }
 
 function closeSidebar() {
 	cy.get('body')
 		.then(($body) => {
 			if ($body.find('.app-sidebar__close').length !== 0) {
-				cy.get('.app-sidebar__close').click()
+				cy.get('.app-sidebar__close').click({ force: true })
 			}
 		})
+	cy.get('#app-sidebar-vue').should('not.exist')
 }
 
 export function showActivityTab(fileName: string) {
@@ -55,14 +56,19 @@ export function removeFromFavorites(fileName: string) {
 	cy.get('.toast-close').click()
 }
 
+/**
+ * Create a new public link share for a given file
+ *
+ * @param fileName Name of the file to share
+ */
 export function createPublicShare(fileName: string) {
-	toggleMenuAction(fileName)
-	cy.contains('Open details').click()
+	showSidebarForFile(fileName)
 	cy.get('#app-sidebar-vue').contains('Sharing').click()
 
-	cy.get('#app-sidebar-vue [data-id="sharing"]').trigger('click')
-	cy.get('#app-sidebar-vue button.new-share-link').trigger('click')
-	cy.get('#app-sidebar-vue a.sharing-entry__copy')
+	cy.get('#app-sidebar-vue #tab-sharing').should('be.visible')
+	cy.get('#app-sidebar-vue button.new-share-link').click({ force: true })
+	cy.get('#app-sidebar-vue a.sharing-entry__copy').should('be.visible')
+	closeSidebar()
 }
 
 export function addTag(fileName: string, tag: string) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -48,5 +48,6 @@
 	</issueHandlers>
 	<stubs>
 		<file name="tests/stubs/oc_hooks_emitter.php" />
+		<file name="tests/stubs/oca_files_event.php" preloadClasses="true"/>
 	</stubs>
 </psalm>

--- a/tests/stubs/oca_files_event.php
+++ b/tests/stubs/oca_files_event.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace OCA\Files\Event {
+	class LoadSidebar extends \OCP\EventDispatcher\Event {
+	}
+}


### PR DESCRIPTION
Fixing:

```
ERROR: InvalidArgument - lib/AppInfo/Application.php:139:13 - Incompatible types found for T (OCA\Files\Event\LoadSidebar|OCP\EventDispatcher\Event is not in OCP\EventDispatcher\Event) (see https://psalm.dev/004)
                $context->registerEventListener(LoadSidebar::class, LoadSidebarScripts::class);
```