### PR TITLE
feat(rss): Add server name to the RSS feed title

### DIFF
--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -25,6 +25,7 @@ namespace OCA\Activity\Controller;
 use OCA\Activity\Data;
 use OCA\Activity\GroupHelper;
 use OCA\Activity\UserSettings;
+use OCA\Theming\ThemingDefaults;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -48,7 +49,9 @@ class FeedController extends Controller {
 		protected IURLGenerator $urlGenerator,
 		protected IManager $activityManager,
 		protected IFactory $l10nFactory,
-		protected IConfig $config) {
+		protected IConfig $config,
+		protected ThemingDefaults $themingDefaults,
+	) {
 		parent::__construct($appName, $request);
 	}
 
@@ -85,11 +88,13 @@ class FeedController extends Controller {
 			];
 		}
 
+		$title = $this->themingDefaults->getTitle();
 		$response = new TemplateResponse('activity', 'rss', [
 			'rssLang' => $this->l->getLanguageCode(),
 			'rssLink' => $this->urlGenerator->linkToRouteAbsolute('activity.Feed.show'),
 			'rssPubDate' => date('r'),
 			'description' => $description,
+			'title' => $title !== '' ? $this->l->t('Activity feed for %1$s', [$title]) : $this->l->t('Activity feed'),
 			'activities' => $activities,
 		], '');
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -50,5 +50,6 @@
 		<file name="tests/stubs/oc_hooks_emitter.php" />
 		<file name="tests/stubs/oca_files_event.php" preloadClasses="true"/>
 		<file name="tests/stubs/oca_viewer_event.php" preloadClasses="true"/>
+		<file name="tests/stubs/oca_theming_defaults.php" preloadClasses="true"/>
 	</stubs>
 </psalm>

--- a/templates/rss.php
+++ b/templates/rss.php
@@ -25,7 +25,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 	<channel>
-		<title><?php p($l->t('Activity feed')); ?></title>
+		<title><?php p($_['title']); ?></title>
 		<language><?php p($_['rssLang']); ?></language>
 		<link><?php p($_['rssLink']); ?></link>
 		<description><?php p($_['description']); ?></description>

--- a/tests/Controller/FeedControllerTest.php
+++ b/tests/Controller/FeedControllerTest.php
@@ -29,6 +29,7 @@ use OCA\Activity\Data;
 use OCA\Activity\GroupHelper;
 use OCA\Activity\Tests\TestCase;
 use OCA\Activity\UserSettings;
+use OCA\Theming\ThemingDefaults;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
@@ -64,6 +65,9 @@ class FeedControllerTest extends TestCase {
 	/** @var \OCP\IL10N */
 	protected $l10n;
 
+	/** @var ThemingDefaults|MockObject */
+	protected $themingDefault;
+
 	/** @var FeedController */
 	protected $controller;
 
@@ -78,6 +82,7 @@ class FeedControllerTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->manager = $this->createMock(IManager::class);
+		$this->themingDefault = $this->createMock(ThemingDefaults::class);
 
 		/** @var $urlGenerator IURLGenerator|MockObject */
 		$urlGenerator = $this->createMock(IURLGenerator::class);
@@ -91,7 +96,8 @@ class FeedControllerTest extends TestCase {
 			$urlGenerator,
 			$this->manager,
 			\OC::$server->getL10NFactory(),
-			$this->config
+			$this->config,
+			$this->themingDefault,
 		);
 	}
 

--- a/tests/Template/RssTest.php
+++ b/tests/Template/RssTest.php
@@ -30,8 +30,8 @@ use OCP\AppFramework\Http\TemplateResponse;
 class RssTest extends TestCase {
 	public function dataEmpty(): array {
 		return [
-			['de', 'http://localhost', 'description', 'Fri, 28 Aug 2015 11:47:14 +0000'],
-			['en', 'http://nextcloud.org', 'Desc', 'Fri, 28 Aug 2015 11:47:15 +0000'],
+			['de', 'http://localhost', 'title', 'description', 'Fri, 28 Aug 2015 11:47:14 +0000'],
+			['en', 'http://nextcloud.org', 'The title', 'Desc', 'Fri, 28 Aug 2015 11:47:15 +0000'],
 		];
 	}
 
@@ -43,12 +43,13 @@ class RssTest extends TestCase {
 	 * @param string $description
 	 * @param string $timeDate
 	 */
-	public function testEmpty(string $language, string $link, string $description, string $timeDate): void {
+	public function testEmpty(string $language, string $link, string $title, string $description, string $timeDate): void {
 		$template = new TemplateResponse('activity', 'rss', [
 			'rssLang' => $language,
 			'rssLink' => $link,
 			'rssPubDate' => $timeDate,
 			'description' => $description,
+			'title' => $title,
 			'activities' => [],
 		], '');
 
@@ -56,7 +57,7 @@ class RssTest extends TestCase {
 			'<?xml version="1.0" encoding="UTF-8"?>'
 			. "\n" . '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">'
 			. "\n" . '	<channel>'
-			. "\n" . '		<title>Activity feed</title>'
+			. "\n" . '		<title>' . $title . '</title>'
 			. "\n" . '		<language>' . $language . '</language>'
 			. "\n" . '		<link>' . $link . '</link>'
 			. "\n" . '		<description>' . $description . '</description>'
@@ -118,6 +119,7 @@ class RssTest extends TestCase {
 			'rssLink' => 'http://nextcloud.org',
 			'rssPubDate' => 'Fri, 28 Aug 2015 11:47:15 +0000',
 			'description' => 'Desc',
+			'title' => 'Activity feed',
 			'activities' => $activities,
 		], '');
 		$rendered = $template->render();

--- a/tests/stubs/oca_theming_defaults.php
+++ b/tests/stubs/oca_theming_defaults.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OCA\Theming {
+	interface ThemingDefaults {
+		public function getName(): string;
+	
+		public function getHTMLName(): string;
+
+		public function getTitle(): string;
+	
+		public function getProductName(): string;
+	
+		public function getBaseUrl(): string;
+
+		public function getSlogan(?string $lang = null): string;
+	
+		public function getImprintUrl(): string;
+	
+		public function getPrivacyUrl(): string;
+	}
+}


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/activity/issues/275

To help you keep track which server stream is which, this adds the cloud title to the RSS feed (that one you configure in admin settings -> theming).