### PR TITLE
fix(notifications): Remove notifications of expired activities

### DIFF
--- a/lib/NotificationGenerator.php
+++ b/lib/NotificationGenerator.php
@@ -26,6 +26,7 @@ namespace OCA\Activity;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager as ActivityManager;
 use OCP\IL10N;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager as NotificationManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
@@ -111,7 +112,10 @@ class NotificationGenerator implements INotifier {
 		}
 
 		$event = $this->data->getById((int)$notification->getObjectId());
-		if (!$event || $event->getAffectedUser() !== $notification->getUser()) {
+		if (!$event) {
+			throw new AlreadyProcessedException();
+		}
+		if ($event->getAffectedUser() !== $notification->getUser()) {
 			throw new \InvalidArgumentException();
 		}
 		$this->activityManager->setCurrentUserId($notification->getUser());


### PR DESCRIPTION
Fixes Checkbox 1 of https://github.com/nextcloud/notifications/issues/1741 at least when they would appear in the list.
DB would still have trash entries when the user never loads the items