### PR TITLE
fix: Replace deprecated function calls and private with public API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
 		"psalm": "psalm.phar --threads=1",
-		"psalm:update-baseline": "psalm.phar--threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
+		"psalm:update-baseline": "psalm.phar --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
 		"psalm:clear": "psalm.phar --clear-cache && psalm.phar--clear-global-cache",
 		"psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MissingParamType,InvalidFalsableReturnType",
 		"test:unit": "vendor/bin/phpunit -c tests/phpunit.xml --color --fail-on-warning --fail-on-risky",

--- a/lib/BackgroundJob/DigestMail.php
+++ b/lib/BackgroundJob/DigestMail.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace OCA\Activity\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
 use OCA\Activity\DigestSender;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 
 class DigestMail extends TimedJob {
 	/** @var DigestSender */

--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -23,8 +23,9 @@
 
 namespace OCA\Activity\BackgroundJob;
 
-use OC\BackgroundJob\TimedJob;
 use OCA\Activity\MailQueueHandler;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 
 /**
  * Class EmailNotification
@@ -32,19 +33,16 @@ use OCA\Activity\MailQueueHandler;
  * @package OCA\Activity\BackgroundJob
  */
 class EmailNotification extends TimedJob {
-	/** @var MailQueueHandler */
-	protected $queueHandler;
 
-	/** @var bool */
-	protected $isCLI;
+	public function __construct(
+		ITimeFactory $time,
+		protected MailQueueHandler $queueHandler,
+		protected bool $isCLI,
+	) {
+		parent::__construct($time);
 
-	public function __construct(MailQueueHandler $mailQueueHandler,
-		bool $isCLI) {
 		// Run everytime cron is executed, so the batching doesn't delay too much
 		$this->setInterval(1);
-
-		$this->queueHandler = $mailQueueHandler;
-		$this->isCLI = $isCLI;
 	}
 
 	protected function run($argument) {

--- a/lib/BackgroundJob/RemoteActivity.php
+++ b/lib/BackgroundJob/RemoteActivity.php
@@ -22,8 +22,8 @@
 namespace OCA\Activity\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
-use OC\BackgroundJob\QueuedJob;
 use OCA\Activity\Extension\Files;
+use OCP\BackgroundJob\QueuedJob;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
@@ -40,8 +40,8 @@ class RemoteActivity extends QueuedJob {
 		$this->cloudIdManager = $cloudIdManager;
 	}
 
-	protected function run($arguments) {
-		call_user_func_array([$this, 'sendActivity'], $arguments);
+	protected function run($argument) {
+		call_user_func_array([$this, 'sendActivity'], $argument);
 	}
 
 	protected function sendActivity($target, $token, $path, $internalType, $time, $actor, $secondPath = '') {

--- a/lib/Controller/APIv1Controller.php
+++ b/lib/Controller/APIv1Controller.php
@@ -27,6 +27,7 @@ use OCA\Activity\GroupHelper;
 use OCA\Activity\UserSettings;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\IDBConnection;
 use OCP\IRequest;
 
 class APIv1Controller extends OCSController {
@@ -43,7 +44,9 @@ class APIv1Controller extends OCSController {
 		protected Data $data,
 		protected GroupHelper $groupHelper,
 		protected UserSettings $userSettings,
-		protected CurrentUser $currentUser) {
+		protected CurrentUser $currentUser,
+		protected IDBConnection $dbConnection,
+	) {
 		parent::__construct($appName, $request);
 	}
 
@@ -85,7 +88,7 @@ class APIv1Controller extends OCSController {
 	 * @return int
 	 */
 	protected function getSinceFromOffset($offset) {
-		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$query = $this->dbConnection->getQueryBuilder();
 		$query->select('activity_id')
 			->from('activity')
 			->where($query->expr()->eq('affecteduser', $query->createNamedParameter($this->currentUser->getUID())))
@@ -93,7 +96,7 @@ class APIv1Controller extends OCSController {
 			->setFirstResult($offset - 1)
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 

--- a/lib/Controller/RemoteActivityController.php
+++ b/lib/Controller/RemoteActivityController.php
@@ -94,7 +94,7 @@ class RemoteActivityController extends OCSController {
 			->where($query->expr()->eq('share_token', $query->createNamedParameter($token)))
 			->andWhere($query->expr()->eq('user', $query->createNamedParameter($user->getUID())));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$share = $result->fetch();
 		$result->closeCursor();
 

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -237,7 +237,7 @@ class Data {
 
 		$query->setMaxResults($limit + 1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$hasMore = false;
 		while ($row = $result->fetch()) {
 			if ($limit === 0) {
@@ -273,7 +273,7 @@ class Data {
 			$queryBuilder->select(['affecteduser', 'timestamp'])
 				->from('activity')
 				->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter((int)$since)));
-			$result = $queryBuilder->execute();
+			$result = $queryBuilder->executeQuery();
 			$activity = $result->fetch();
 			$result->closeCursor();
 
@@ -303,7 +303,7 @@ class Data {
 			->where($fetchQuery->expr()->eq('affecteduser', $fetchQuery->createNamedParameter($user)))
 			->orderBy('timestamp', $sort)
 			->setMaxResults(1);
-		$result = $fetchQuery->execute();
+		$result = $fetchQuery->executeQuery();
 		$activity = $result->fetch();
 		$result->closeCursor();
 
@@ -393,7 +393,7 @@ class Data {
 			->from('activity')
 			->where($query->expr()->eq('activity_id', $query->createNamedParameter($activityId)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$event = $this->activityManager->generateEvent();
 			$event->setApp((string)$row['app'])
@@ -428,7 +428,7 @@ class Data {
 			->orderBy('timestamp', 'ASC')
 			->setMaxResults(1);
 
-		$res = $query->execute()->fetch(\PDO::FETCH_COLUMN);
+		$res = $query->executeQuery()->fetch(\PDO::FETCH_COLUMN);
 		return (int)$res;
 	}
 
@@ -453,7 +453,7 @@ class Data {
 			$query->andWhere($query->expr()->neq('user', $nameParam));
 		}
 
-		return $query->execute()->fetch();
+		return $query->executeQuery()->fetch();
 	}
 
 	/**

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -188,7 +188,7 @@ class MailQueueHandler {
 			}
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$affectedUsers = [];
 		while ($row = $result->fetch()) {
@@ -215,7 +215,7 @@ class MailQueueHandler {
 			->andWhere($query->expr()->eq('amq_affecteduser', $query->createNamedParameter($affectedUser)))
 			->orderBy('amq_timestamp', 'ASC')
 			->setMaxResults($maxNumItems);
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$activities = [];
 		while ($row = $result->fetch()) {
@@ -230,7 +230,7 @@ class MailQueueHandler {
 				->from('activity_mq')
 				->where($query->expr()->lte('amq_timestamp', $query->createNamedParameter($maxTime)))
 				->andWhere($query->expr()->eq('amq_affecteduser', $query->createNamedParameter($affectedUser)));
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$row = $result->fetch();
 			$result->closeCursor();
 
@@ -492,6 +492,6 @@ class MailQueueHandler {
 		$query->delete('activity_mq')
 			->where($query->expr()->lte('amq_timestamp', $query->createNamedParameter($maxTime, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->in('amq_affecteduser', $query->createNamedParameter($affectedUsers, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR));
-		$query->execute();
+		$query->executeStatement();
 	}
 }

--- a/tests/AppInfo/ApplicationTest.php
+++ b/tests/AppInfo/ApplicationTest.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
 
 namespace OCA\Activity\Tests\AppInfo;
 
-use OC\BackgroundJob\TimedJob;
 use OC\Files\View;
 use OCA\Activity\AppInfo\Application;
 use OCA\Activity\BackgroundJob\EmailNotification;
@@ -50,6 +49,7 @@ use OCP\Activity\IConsumer;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\OCSController;
+use OCP\BackgroundJob\TimedJob;
 use OCP\Capabilities\ICapability;
 use OCP\IL10N;
 
@@ -101,7 +101,7 @@ class ApplicationTest extends TestCase {
 			[EmailNotification::class],
 			[EmailNotification::class, TimedJob::class],
 			[ExpireActivities::class,],
-			[ExpireActivities::class, \OCP\BackgroundJob\TimedJob::class],
+			[ExpireActivities::class, TimedJob::class],
 
 			// Controller
 			[ActivitiesController::class],

--- a/tests/BackgroundJob/EmailNotificationTest.php
+++ b/tests/BackgroundJob/EmailNotificationTest.php
@@ -24,12 +24,11 @@ declare(strict_types=1);
 
 namespace OCA\Activity\Tests\BackgroundJob;
 
-use OC\BackgroundJob\JobList;
 use OCA\Activity\BackgroundJob\EmailNotification;
 use OCA\Activity\MailQueueHandler;
 use OCA\Activity\Tests\TestCase;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
-use OCP\ILogger;
 
 /**
  * Class EmailNotificationTest
@@ -51,15 +50,15 @@ class EmailNotificationTest extends TestCase {
 	 */
 	public function testConstructAndRun(bool $isCLI): void {
 		$backgroundJob = new EmailNotification(
+			$this->createMock(ITimeFactory::class),
 			$this->createMock(MailQueueHandler::class),
 			$isCLI
 		);
 
 		$jobList = $this->createMock(IJobList::class);
-		$logger = $this->createMock(ILogger::class);
 
-		/** @var JobList $jobList */
-		$backgroundJob->execute($jobList, $logger);
+		/** @var IJobList $jobList */
+		$backgroundJob->start($jobList);
 		$this->assertTrue(true);
 	}
 }

--- a/tests/Controller/APIv1ControllerTest.php
+++ b/tests/Controller/APIv1ControllerTest.php
@@ -232,7 +232,8 @@ class APIv1ControllerTest extends TestCase {
 			$data,
 			new GroupHelper($l, $activityManager, $this->createMock(IValidator::class), $this->createMock(LoggerInterface::class)),
 			new UserSettings($activityManager, $config),
-			$currentUser
+			$currentUser,
+			\OC::$server->getDatabaseConnection(),
 		);
 		$response = $controller->get($start, $count);
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,108 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.3.2@57b53ff26237074fdf5cbcb034f7da5172be4524">
-  <file src="lib/BackgroundJob/DigestMail.php">
-    <UndefinedClass occurrences="1">
-      <code>TimedJob</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/BackgroundJob/EmailNotification.php">
-    <UndefinedClass occurrences="1">
-      <code>TimedJob</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/BackgroundJob/ExpireActivities.php">
-    <UndefinedClass occurrences="1">
-      <code>TimedJob</code>
-    </UndefinedClass>
-  </file>
+<files psalm-version="5.19.0@06b71be009a6bd6d81b9811855d6629b9fe90e1b">
   <file src="lib/BackgroundJob/RemoteActivity.php">
-    <UndefinedClass occurrences="1">
-      <code>QueuedJob</code>
+    <UndefinedClass>
+      <code>ClientException</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Controller/APIv2Controller.php">
-    <RedundantCondition occurrences="1">
-      <code>'files'</code>
-    </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
-      <code>$info['view']</code>
-    </TypeDoesNotContainType>
-  </file>
-  <file src="lib/Controller/ActivitiesController.php">
-    <InvalidArgument occurrences="2">
-      <code>$event</code>
-      <code>'OCA\Activity::loadAdditionalScripts'</code>
-    </InvalidArgument>
-  </file>
-  <file src="lib/Controller/RemoteActivityController.php">
-    <MissingDependency occurrences="3">
-      <code>$this-&gt;rootFolder</code>
-      <code>IRootFolder</code>
-      <code>IRootFolder</code>
-    </MissingDependency>
   </file>
   <file src="lib/CurrentUser.php">
-    <MissingDependency occurrences="1">
-      <code>ShareNotFound</code>
-    </MissingDependency>
-    <NoInterfaceProperties occurrences="1">
-      <code>$this-&gt;request-&gt;server</code>
+    <NoInterfaceProperties>
+      <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
   <file src="lib/Data.php">
-    <UndefinedDocblockClass occurrences="1">
-      <code>$favoriteFilter-&gt;filterFavorites($query);</code>
+    <UndefinedDocblockClass>
+      <code><![CDATA[$favoriteFilter->filterFavorites($query);]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="lib/DigestSender.php">
-    <InvalidArrayOffset occurrences="1">
-      <code>[$user-&gt;getEMailAddress() =&gt; $user-&gt;getDisplayName()]</code>
+    <InvalidArrayOffset>
+      <code><![CDATA[[$user->getEMailAddress() => $user->getDisplayName()]]]></code>
     </InvalidArrayOffset>
   </file>
   <file src="lib/FilesHooks.php">
-    <MissingDependency occurrences="3">
-      <code>$this-&gt;rootFolder</code>
-      <code>IRootFolder</code>
-      <code>IRootFolder</code>
-    </MissingDependency>
-    <UndefinedDocblockClass occurrences="4">
-      <code>$mount-&gt;getStorage()</code>
+    <InvalidArgument>
+      <code><![CDATA[$share->getId()]]></code>
+    </InvalidArgument>
+    <UndefinedDocblockClass>
       <code>$shareOwner</code>
-      <code>$storage</code>
       <code>$storage</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="lib/Migration/Version2007Date20181107114613.php">
-    <UndefinedClass occurrences="2">
-      <code>Type</code>
-      <code>Type</code>
-    </UndefinedClass>
-  </file>
   <file src="lib/Migration/Version2008Date20181011095117.php">
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>SchemaException</code>
     </UndefinedClass>
   </file>
   <file src="lib/Migration/Version2011Date20201006132544.php">
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>Type</code>
     </UndefinedClass>
   </file>
   <file src="lib/Migration/Version2011Date20201006132545.php">
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>Type</code>
     </UndefinedClass>
-  </file>
-  <file src="lib/Navigation.php">
-    <MissingDependency occurrences="2">
-      <code>Template</code>
-      <code>\OCP\Template</code>
-    </MissingDependency>
-  </file>
-  <file src="lib/UserSettings.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>$defaultSetting</code>
-      <code>$defaultSetting</code>
-    </InvalidScalarArgument>
   </file>
 </files>


### PR DESCRIPTION
* Replace deprecated `execute` with `executeQuery` or `executeStatement`.
* Replace private `OC\BackgroundJob\...` with public `OCP\BackgroundJob\...`
* Do not use private `\OC::$server` but use dependency injection