### PR TITLE
fix: Migrate `post_share` hook to event listener

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -53,6 +53,7 @@ use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Share\Events\BeforeShareDeletedEvent;
+use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedFromSelfEvent;
 use OCP\User\Events\PostLoginEvent;
 use OCP\User\Events\UserDeletedEvent;
@@ -178,8 +179,8 @@ class Application extends App implements IBootstrap {
 		Util::connectHook('OC_Filesystem', 'rename', FilesHooksStatic::class, 'fileMove');
 		Util::connectHook('OC_Filesystem', 'post_rename', FilesHooksStatic::class, 'fileMovePost');
 		Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', FilesHooksStatic::class, 'fileRestore');
-		Util::connectHook('OCP\Share', 'post_shared', FilesHooksStatic::class, 'share');
 
+		$context->registerEventListener(ShareCreatedEvent::class, ShareEventListener::class);
 		$context->registerEventListener(BeforeShareDeletedEvent::class, ShareEventListener::class);
 		$context->registerEventListener(ShareDeletedFromSelfEvent::class, ShareEventListener::class);
 	}

--- a/lib/FilesHooksStatic.php
+++ b/lib/FilesHooksStatic.php
@@ -82,12 +82,4 @@ class FilesHooksStatic {
 	public static function fileRestore($params) {
 		self::getHooks()->fileRestore($params['filePath']);
 	}
-
-	/**
-	 * Manage sharing events
-	 * @param array $params The hook params
-	 */
-	public static function share($params) {
-		self::getHooks()->share($params);
-	}
 }

--- a/lib/Listener/ShareEventListener.php
+++ b/lib/Listener/ShareEventListener.php
@@ -26,6 +26,7 @@ use OCA\Activity\FilesHooks;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Share\Events\BeforeShareDeletedEvent;
+use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedFromSelfEvent;
 
 /**
@@ -47,6 +48,18 @@ class ShareEventListener implements IEventListener {
 		if ($event instanceof ShareDeletedFromSelfEvent) {
 			$this->unShareSelf($event);
 		}
+
+		if ($event instanceof ShareCreatedEvent) {
+			$this->createShare($event);
+		}
+	}
+
+	/**
+	 * Node shared event
+	 */
+	public function createShare(ShareCreatedEvent $event): void {
+		$share = $event->getShare();
+		$this->fileHooks->share($share);
 	}
 
 	/**

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -43,6 +43,7 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\Share\IManager as ShareIManager;
 use OCP\Share\IShare;
 use OCP\Share\IShareHelper;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -485,13 +486,16 @@ class FilesHooksTest extends TestCase {
 			->method('shareWithUser')
 			->with('u1', 1337, 'file', 'path');
 
-		$filesHooks->share([
-			'fileSource' => 1337,
-			'shareType' => IShare::TYPE_USER,
-			'shareWith' => 'u1',
-			'itemType' => 'file',
-			'fileTarget' => 'path',
-		]);
+		/** @var ShareIManager */
+		$manager = \OC::$server->get(ShareIManager::class);
+		$share = $manager->newShare();
+		$share->setSharedWith('u1');
+		$share->setShareType(IShare::TYPE_USER);
+		$share->setTarget('path');
+		$share->setNodeType('file');
+		$share->setNodeId(1337);
+
+		$filesHooks->share($share);
 	}
 
 	public function testHookShareWithGroup(): void {
@@ -503,14 +507,17 @@ class FilesHooksTest extends TestCase {
 			->method('shareWithGroup')
 			->with('g1', 1337, 'file', 'path', 42);
 
-		$filesHooks->share([
-			'fileSource' => 1337,
-			'shareType' => IShare::TYPE_GROUP,
-			'shareWith' => 'g1',
-			'itemType' => 'file',
-			'fileTarget' => 'path',
-			'id' => '42',
-		]);
+		/** @var ShareIManager */
+		$manager = \OC::$server->get(ShareIManager::class);
+		$share = $manager->newShare();
+		$share->setId('42');
+		$share->setSharedWith('g1');
+		$share->setShareType(IShare::TYPE_GROUP);
+		$share->setTarget('path');
+		$share->setNodeType('file');
+		$share->setNodeId(1337);
+
+		$filesHooks->share($share);
 	}
 
 	public function testShareViaPublicLink(): void {
@@ -522,12 +529,15 @@ class FilesHooksTest extends TestCase {
 			->method('shareByLink')
 			->with(1337, 'file', 'admin');
 
-		$filesHooks->share([
-			'fileSource' => 1337,
-			'shareType' => IShare::TYPE_LINK,
-			'itemType' => 'file',
-			'uidOwner' => 'admin',
-		]);
+		/** @var ShareIManager */
+		$manager = \OC::$server->get(ShareIManager::class);
+		$share = $manager->newShare();
+		$share->setShareType(IShare::TYPE_LINK);
+		$share->setNodeType('file');
+		$share->setNodeId(1337);
+		$share->setSharedBy('admin');
+
+		$filesHooks->share($share);
 	}
 
 	public function dataShareWithUser(): array {


### PR DESCRIPTION
Move the legacy hook to typed event for new created shares.