### PR TITLE
Make container view looks proportional on viewport

### DIFF
--- a/src/views/ActivityAppFeed.vue
+++ b/src/views/ActivityAppFeed.vue
@@ -208,12 +208,10 @@ watch(props, () => {
 	&__container {
 		display: flex;
 		flex-direction: column;
-
 		height: 100%;
-		width: min(100%, 924px);
-		max-width: 924px;
-		margin: 0 auto;
-		padding-inline: 12px;
+		// Align with app navigation toggle
+		margin: var(--app-navigation-padding, 8px) 0 0 calc(2 * var(--app-navigation-padding, 8px) + 44px)
+		padding-inline: 0 44px;
 		overflow-y: scroll;
 	}
 


### PR DESCRIPTION
On big screen resolution, actual implementation with fixed with looks like an iframe.
Make it fluid and align with other items on screen.

## Before
![image](https://github.com/nextcloud/activity/assets/12234510/193dff1a-7861-4e97-bf4e-c40f830fbe27)

## After
![image](https://github.com/nextcloud/activity/assets/12234510/e74d041b-28ea-442f-b2ac-b8eedab99458)
