### PR TITLE
fix access array offset in FilesHook.php

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -242,6 +242,9 @@ class FilesHooks {
 			return;
 		}
 
+		// cache moveCase result until attributes are calculated for next stage (fileMovePost)
+		// moveCase has to be set as last part before return
+		$moveCase = $this->moveCase;
 		if (strpos($oldDir, $newDir) === 0) {
 			/**
 			 * a/b/c moved to a/c
@@ -251,7 +254,7 @@ class FilesHooks {
 			 * - a/b/ shared: delete
 			 * - a/ shared: move/rename
 			 */
-			$this->moveCase = 'moveUp';
+			$moveCase = 'moveUp';
 		} elseif (strpos($newDir, $oldDir) === 0) {
 			/**
 			 * a/b moved to a/c/b
@@ -261,7 +264,7 @@ class FilesHooks {
 			 * - a/c/ shared: add
 			 * - a/ shared: move/rename
 			 */
-			$this->moveCase = 'moveDown';
+			$moveCase = 'moveDown';
 		} else {
 			/**
 			 * a/b/c moved to a/d/c
@@ -272,7 +275,7 @@ class FilesHooks {
 			 * - a/d/ shared: add
 			 * - a/ shared: move/rename
 			 */
-			$this->moveCase = 'moveCross';
+			$moveCase = 'moveCross';
 		}
 
 		[$this->oldParentPath, $this->oldParentOwner, $this->oldParentId] = $this->getSourcePathAndOwner($oldDir);
@@ -291,6 +294,9 @@ class FilesHooks {
 		}
 
 		$this->oldAccessList = $oldAccessList;
+
+		// now its save to set moveCase
+		$this->moveCase = $moveCase;
 	}
 
 

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -578,6 +578,8 @@ class FilesHooks {
 		try {
 			$node = $this->rootFolder->getUserFolder($uidOwner)->get($path);
 		} catch (NotFoundException $e) {
+			$this->logger->warning('Path "{path}" with owner "{uidOwner}" was not found',
+				['path'=> $path, 'uidOwner'=>$uidOwner]);
 			return [
 				'users' => [],
 				'remotes' => [],
@@ -585,6 +587,8 @@ class FilesHooks {
 		}
 
 		if (!$node instanceof Node) {
+			$this->logger->warning('Path "{path}" of "{uidOwner}" is not a valid type.',
+				['path'=> $path, 'uidOwner'=>$uidOwner]);
 			return [
 				'users' => [],
 				'remotes' => [],

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -578,11 +578,17 @@ class FilesHooks {
 		try {
 			$node = $this->rootFolder->getUserFolder($uidOwner)->get($path);
 		} catch (NotFoundException $e) {
-			return [];
+			return [
+				'users' => [],
+				'remotes' => [],
+			];
 		}
 
 		if (!$node instanceof Node) {
-			return [];
+			return [
+				'users' => [],
+				'remotes' => [],
+			];
 		}
 
 		$accessList = $this->shareHelper->getPathsForAccessList($node);


### PR DESCRIPTION
prevent access array offset which doesn't exist and check if returned value is null

fixes #1056 

The Problem is related to the empty default array:
https://github.com/nextcloud/activity/blob/22bf3f2329e5c1e7cf2b9fa627a59c02ae8ae86a/lib/FilesHooks.php#L569-L580

compared to server implemented skeleton:
https://github.com/nextcloud/server/blob/d237fd0e78af8bbff51f2802efd4db1d88457579/lib/private/Share20/ShareHelper.php#L27-L32
```php
	public function getPathsForAccessList(Node $node) {
		$result = [
			'users' => [],
			'remotes' => [],
		];
```