### PR TITLE
fix: split link upload activity type

### DIFF
--- a/lib/Extension/Files_Sharing.php
+++ b/lib/Extension/Files_Sharing.php
@@ -8,4 +8,5 @@ namespace OCA\Activity\Extension;
 
 class Files_Sharing {
 	public const TYPE_SHARED = 'shared';
+	public const TYPE_PUBLIC_UPLOAD = 'public_links_upload';
 }

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -77,7 +77,7 @@ class FilesHooks {
 		if ($this->currentUser->getUserIdentifier() !== '') {
 			$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_CREATED, 'created_self', 'created_by');
 		} else {
-			$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_CREATED, '', 'created_public');
+			$this->addNotificationsForFileAction($path, Files_Sharing::TYPE_PUBLIC_UPLOAD, '', 'created_public');
 		}
 	}
 
@@ -108,9 +108,9 @@ class FilesHooks {
 		$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_RESTORED, 'restored_self', 'restored_by');
 	}
 
-	private function getFileChangeActivitySettings(int $fileId, array $users): array {
-		$filteredEmailUsers = $this->userSettings->filterUsersBySetting($users, 'email', Files::TYPE_FILE_CHANGED);
-		$filteredNotificationUsers = $this->userSettings->filterUsersBySetting($users, 'notification', Files::TYPE_FILE_CHANGED);
+	private function getFileChangeActivitySettings(int $fileId, array $users, $type = Files::TYPE_FILE_CHANGED): array {
+		$filteredEmailUsers = $this->userSettings->filterUsersBySetting($users, 'email', $type);
+		$filteredNotificationUsers = $this->userSettings->filterUsersBySetting($users, 'notification', $type);
 
 		/** @psalm-suppress UndefinedMethod */
 		$favoriteUsers = $this->tagManager->getUsersFavoritingObject('files', $fileId);
@@ -159,7 +159,7 @@ class FilesHooks {
 		}
 
 		[$filteredEmailUsers, $filteredNotificationUsers] =
-			$this->getFileChangeActivitySettings($fileId, array_keys($affectedUsers));
+			$this->getFileChangeActivitySettings($fileId, array_keys($affectedUsers), $activityType);
 
 		foreach ($affectedUsers as $user => $path) {
 			$user = (string)$user;

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -178,8 +178,8 @@ class FilesHooksTest extends TestCase {
 
 	public function dataFileCreate(): array {
 		return [
-			['user', 'created_self', 'created_by'],
-			['', '', 'created_public'],
+			['user', 'created_self', 'created_by', Files::TYPE_SHARE_CREATED],
+			['', '', 'created_public', Files_Sharing::TYPE_PUBLIC_UPLOAD],
 		];
 	}
 
@@ -190,14 +190,14 @@ class FilesHooksTest extends TestCase {
 	 * @param string $selfSubject
 	 * @param string $othersSubject
 	 */
-	public function testFileCreate(string $currentUser, string $selfSubject, string $othersSubject): void {
+	public function testFileCreate(string $currentUser, string $selfSubject, string $othersSubject, string $type): void {
 		$filesHooks = $this->getFilesHooks([
 			'addNotificationsForFileAction',
 		], $currentUser);
 
 		$filesHooks->expects($this->once())
 			->method('addNotificationsForFileAction')
-			->with('path', Files::TYPE_SHARE_CREATED, $selfSubject, $othersSubject);
+			->with('path', $type, $selfSubject, $othersSubject);
 
 		$filesHooks->fileCreate('path');
 	}


### PR DESCRIPTION
Works with https://github.com/nextcloud/server/pull/46945

I'm not so fond of the way it works, but the activity api handles things like this.
I would have liked notifications to be bound to the event category and not the event identifier, but that's not how it was designed :shrug: 