### PR TITLE
feat: Add sharing activity for teams

### DIFF
--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -39,6 +39,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -57,33 +58,25 @@ use Psr\Log\LoggerInterface;
  * @package OCA\Activity
  */
 class FilesHooksTest extends TestCase {
-	/** @var FilesHooks */
-	protected $filesHooks;
-	/** @var IManager|MockObject */
-	protected $activityManager;
-	/** @var Data|MockObject */
-	protected $data;
-	/** @var UserSettings|MockObject */
-	protected $settings;
-	/** @var IGroupManager|MockObject */
-	protected $groupManager;
-	/** @var View|MockObject */
-	protected $view;
-	/** @var IRootFolder|MockObject */
-	protected $rootFolder;
-	/** @var IShareHelper|MockObject */
-	protected $shareHelper;
-	/** @var IURLGenerator|MockObject */
-	protected $urlGenerator;
-	/** @var IUserMountCache|MockObject */
-	protected $userMountCache;
-	/** @var IConfig|MockObject */
-	protected $config;
-	/** @var NotificationGenerator|MockObject */
-	protected $notificationGenerator;
-	/** @var TagManager|MockObject */
-	protected $tagManager;
+	protected FilesHooks $filesHooks;
+	protected IManager&MockObject $activityManager;
+	protected Data&MockObject $data;
+	protected UserSettings&MockObject $settings;
+	protected IGroupManager&MockObject $groupManager;
+	protected View&MockObject $view;
+	protected IRootFolder&MockObject $rootFolder;
+	protected IShareHelper&MockObject $shareHelper;
+	protected IURLGenerator&MockObject $urlGenerator;
+	protected IUserMountCache&MockObject $userMountCache;
+	protected IConfig&MockObject $config;
+	protected NotificationGenerator&MockObject $notificationGenerator;
+	protected TagManager&MockObject $tagManager;
 	protected $tags;
+	/**
+	 * @todo With PHP 8.2 we can put this directly on the declaration instead of a comment but 8.1 does not allow the parenthesis
+	 * @var (OCA\Circles\CirclesManager&MockObject)|null
+	 */
+	protected $teamManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -103,6 +96,7 @@ class FilesHooksTest extends TestCase {
 		$this->tags = $this->createMock(Tags::class);
 		$this->tagManager->method('getUsersFavoritingObject')
 			->willReturn([]);
+		$this->teamManager = null;
 
 		$this->tagManager->method('load')
 			->willReturn($this->tags);
@@ -113,7 +107,7 @@ class FilesHooksTest extends TestCase {
 	/**
 	 * @param array $mockedMethods
 	 * @param string $user
-	 * @return FilesHooks|MockObject
+	 * @return FilesHooks&MockObject
 	 */
 	protected function getFilesHooks(array $mockedMethods = [], string $user = 'user'): FilesHooks {
 		$currentUser = $this->createMock(CurrentUser::class);
@@ -136,14 +130,15 @@ class FilesHooksTest extends TestCase {
 					$this->view,
 					$this->rootFolder,
 					$this->shareHelper,
-					\OC::$server->getDatabaseConnection(),
+					\OCP\Server::get(IDBConnection::class),
 					$this->urlGenerator,
 					$logger,
 					$currentUser,
 					$this->userMountCache,
 					$this->config,
 					$this->notificationGenerator,
-					$this->tagManager
+					$this->tagManager,
+					$this->teamManager,
 				])
 				->onlyMethods($mockedMethods)
 				->getMock();
@@ -157,14 +152,15 @@ class FilesHooksTest extends TestCase {
 			$this->view,
 			$this->rootFolder,
 			$this->shareHelper,
-			\OC::$server->getDatabaseConnection(),
+			\OCP\Server::get(IDBConnection::class),
 			$this->urlGenerator,
 			$logger,
 			$currentUser,
 			$this->userMountCache,
 			$this->config,
 			$this->notificationGenerator,
-			$this->tagManager
+			$this->tagManager,
+			$this->teamManager,
 		);
 	}
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.19.0@06b71be009a6bd6d81b9811855d6629b9fe90e1b">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="lib/BackgroundJob/RemoteActivity.php">
     <UndefinedClass>
-      <code>ClientException</code>
+      <code><![CDATA[ClientException]]></code>
     </UndefinedClass>
   </file>
   <file src="lib/CurrentUser.php">
@@ -21,27 +21,30 @@
     </InvalidArrayOffset>
   </file>
   <file src="lib/FilesHooks.php">
-    <InvalidArgument>
-      <code><![CDATA[$share->getId()]]></code>
-    </InvalidArgument>
+    <UndefinedClass>
+      <code><![CDATA[$this->teamManager]]></code>
+      <code><![CDATA[$this->teamManager]]></code>
+      <code><![CDATA[Member]]></code>
+      <code><![CDATA[protected]]></code>
+    </UndefinedClass>
     <UndefinedDocblockClass>
-      <code>$shareOwner</code>
-      <code>$storage</code>
+      <code><![CDATA[$shareOwner]]></code>
+      <code><![CDATA[$storage]]></code>
     </UndefinedDocblockClass>
   </file>
   <file src="lib/Migration/Version2008Date20181011095117.php">
     <UndefinedClass>
-      <code>SchemaException</code>
+      <code><![CDATA[SchemaException]]></code>
     </UndefinedClass>
   </file>
   <file src="lib/Migration/Version2011Date20201006132544.php">
     <UndefinedClass>
-      <code>Type</code>
+      <code><![CDATA[Type]]></code>
     </UndefinedClass>
   </file>
   <file src="lib/Migration/Version2011Date20201006132545.php">
     <UndefinedClass>
-      <code>Type</code>
+      <code><![CDATA[Type]]></code>
     </UndefinedClass>
   </file>
 </files>


### PR DESCRIPTION
This adds support for Teams (previously "Circles"), the user notification already work, but the notification for the owner and sharer need support in the `files_sharing` app.

So if this is merged we can add the required providers in `files_sharing`.

But one thing to mention: For groups we paginate the members, I did not find a nice way to do this with teams.
So maybe @ArtificialOwl can have a look at the member query if there is something to improve performance wise (e.g. pagination?).