### PR TITLE
Remove requiring PNG for iOS

### DIFF
--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -184,7 +184,7 @@ class APIv2Controller extends OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$this->activityManager->setRequirePNG($this->request->isUserAgent([IRequest::USER_AGENT_CLIENT_IOS]));
+		$this->activityManager->setRequirePNG(false);
 		try {
 			$response = $this->data->get(
 				$this->helper,

--- a/tests/Controller/APIv1ControllerTest.php
+++ b/tests/Controller/APIv1ControllerTest.php
@@ -208,7 +208,8 @@ class APIv1ControllerTest extends TestCase {
 			$this->createMock(IUserSession::class),
 			$config,
 			\OC::$server->query(IValidator::class),
-			$this->createMock(IL10N::class)
+			\OC::$server->query(\OCP\RichObjectStrings\IRichTextFormatter::class),
+			$this->createMock(IL10N::class),
 		);
 		$activityManager->registerProvider(Provider::class);
 		$activityManager->registerSetting(Setting1::class);


### PR DESCRIPTION
PNGs sent are low quality, and iOS supports SVGs being sent.