### PR TITLE
fix/remote activity constructor

### DIFF
--- a/lib/BackgroundJob/RemoteActivity.php
+++ b/lib/BackgroundJob/RemoteActivity.php
@@ -15,16 +15,12 @@ use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
 
 class RemoteActivity extends QueuedJob {
-	/** @var IClientService */
-	protected $clientService;
-
-	/** @var ICloudIdManager */
-	protected $cloudIdManager;
-
-	public function __construct(ITimeFactory $timeFactory, IClientService $clientService, ICloudIdManager $cloudIdManager) {
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private readonly IClientService $clientService,
+		private readonly ICloudIdManager $cloudIdManager,
+	) {
 		parent::__construct($timeFactory);
-		$this->clientService = $clientService;
-		$this->cloudIdManager = $cloudIdManager;
 	}
 
 	protected function run($argument) {

--- a/lib/BackgroundJob/RemoteActivity.php
+++ b/lib/BackgroundJob/RemoteActivity.php
@@ -8,6 +8,7 @@ namespace OCA\Activity\BackgroundJob;
 
 use GuzzleHttp\Exception\ClientException;
 use OCA\Activity\Extension\Files;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\QueuedJob;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
@@ -20,7 +21,8 @@ class RemoteActivity extends QueuedJob {
 	/** @var ICloudIdManager */
 	protected $cloudIdManager;
 
-	public function __construct(IClientService $clientService, ICloudIdManager $cloudIdManager) {
+	public function __construct(ITimeFactory $timeFactory, IClientService $clientService, ICloudIdManager $cloudIdManager) {
+		parent::__construct($timeFactory);
 		$this->clientService = $clientService;
 		$this->cloudIdManager = $cloudIdManager;
 	}


### PR DESCRIPTION
The queued job class requires to pass an `ITimeFactory` to its constructor, otherwise we may see errors like:

> Typed property OCP\BackgroundJob\Job::$time must not be accessed before initialization

Seen logged on our instance 18k times in the last 90 days