### PR TITLE
Revert "[stable28] fix/remote activity constructor"

### DIFF
--- a/lib/BackgroundJob/RemoteActivity.php
+++ b/lib/BackgroundJob/RemoteActivity.php
@@ -24,7 +24,6 @@ namespace OCA\Activity\BackgroundJob;
 use GuzzleHttp\Exception\ClientException;
 use OC\BackgroundJob\QueuedJob;
 use OCA\Activity\Extension\Files;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
 use OCP\Http\Client\IClientService;
@@ -36,8 +35,7 @@ class RemoteActivity extends QueuedJob {
 	/** @var ICloudIdManager */
 	protected $cloudIdManager;
 
-	public function __construct(ITimeFactory $timeFactory, IClientService $clientService, ICloudIdManager $cloudIdManager) {
-		parent::__construct($timeFactory);
+	public function __construct(IClientService $clientService, ICloudIdManager $cloudIdManager) {
 		$this->clientService = $clientService;
 		$this->cloudIdManager = $cloudIdManager;
 	}


### PR DESCRIPTION
Reverts nextcloud/activity#1813 as the code in 28 does not have the original issue.

The bug was only introduced in https://github.com/nextcloud/activity/commit/c8248b0114ea53c19c4298714c51090ae3252b15 for 29 and later