### PR TITLE
fix(settings): ensure we handle file_created, file_deleted and file_restored as file_changed

### DIFF
--- a/lib/UserSettings.php
+++ b/lib/UserSettings.php
@@ -7,6 +7,7 @@
 
 namespace OCA\Activity;
 
+use OCA\Activity\Extension\Files;
 use OCP\Activity\ActivitySettings;
 use OCP\Activity\Exceptions\SettingNotFoundException;
 use OCP\Activity\IManager;
@@ -173,9 +174,14 @@ class UserSettings {
 		$return = array_map(function (ActivitySettings $setting) {
 			return $setting->getIdentifier();
 		}, $settings);
-		if (array_search('file_changed', $return) !== false) {
-			array_push($return, 'file_created', 'file_deleted', 'file_restored');
+
+		// TYPE_FILE_CHANGED is used to group all file changes together
+		// But we still differentiate between file_created, file_deleted and file_restored
+		// so let's add them to the list.
+		if (array_search(Files::TYPE_FILE_CHANGED, $return) !== false) {
+			array_push($return, Files::TYPE_SHARE_CREATED, Files::TYPE_SHARE_DELETED, Files::TYPE_SHARE_RESTORED);
 		}
+
 		return $return;
 	}
 
@@ -195,6 +201,11 @@ class UserSettings {
 
 		if ($method === 'email' && $this->config->getAppValue('activity', 'enable_email', 'yes') === 'no') {
 			return [];
+		}
+
+		// file_created, file_deleted and file_restored are grouped under file_changed
+		if ($type === Files::TYPE_SHARE_CREATED || $type === Files::TYPE_SHARE_DELETED || $type === Files::TYPE_SHARE_RESTORED) {
+			$type = Files::TYPE_FILE_CHANGED;
 		}
 
 		$filteredUsers = [];


### PR DESCRIPTION
The provider is `file_changed`, but we still have some related events. But they are still covered under one setting provider: https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/apps/files/lib/Activity/Settings/FileChanged.php

![image](https://github.com/user-attachments/assets/304faf2d-80dc-4259-b79b-403e1633afca)

Fix https://github.com/nextcloud/server/issues/49133
Fix https://github.com/nextcloud/activity/issues/1889
