### PR TITLE
docs: Fix rich subject parameter casting in example

### DIFF
--- a/docs/provider.md
+++ b/docs/provider.md
@@ -69,7 +69,7 @@ $event->setRichSubject(
 	$this->l->t('You added {file} to your favorites')
 	['file' => [
 		'type' => 'file',
-		'id' => $event->getObjectId(),
+		'id' => (string)$event->getObjectId(),
 		'name' => basename($event->getObjectName()),
 		'path' => $event->getObjectName(),
 	]]


### PR DESCRIPTION
`id` needs to be a string according to the definitions. Otherwise it'll generate an "Object for placeholder file is invalid, value 0 for key id is not a string"

Came up while looking into:

#1967
nextcloud/server#51427

Refs:

nextcloud/server#47662

Perhaps we should also add some language about troubleshooting and isolating these problems, given the recent adjustments in the logging. The placeholders/etc are now logged (nextcloud/server#51442), but it's still a PITA to figure out which app's provider is causing it.

