### PR TITLE
Fix multiple cypress issues

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -149,10 +149,10 @@ jobs:
 
       - name: Extract NC logs
         if: failure() && matrix.containers != 'component'
-        run: docker logs nextcloud-cypress-tests-${{ env.APP_NAME }} > nextcloud.log
+        run: docker logs nextcloud-cypress-tests_${{ env.APP_NAME }} > nextcloud.log
 
       - name: Upload NC logs
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure() && matrix.containers != 'component'
         with:
           name: nc_logs_${{ matrix.containers }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         # Run multiple copies of the current job in parallel
         # Please increase the number or runners as your tests suite grows
-        containers: ['1', '2', '3']
+        containers: ['1', '2']
 
     name: runner ${{ matrix.containers }}
 
@@ -138,12 +138,14 @@ jobs:
           CYPRESS_BUILD_ID: ${{ github.sha }}-${{ github.run_number }}
           CYPRESS_GROUP: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }}
 
-      - name: Upload snapshots
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      - name: Upload snapshots and videos
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: snapshots_${{ matrix.containers }}
-          path: cypress/snapshots
+          name: snapshots_videos_${{ matrix.containers }}
+          path: |
+            cypress/snapshots
+            cypress/videos
 
       - name: Extract NC logs
         if: failure() && matrix.containers != 'component'

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
 	// Needed to trigger `after:run` events with cypress open
 	experimentalInteractiveRunEvents: true,
 
+	// disabled if running in CI but enabled in debug mode
+	video: !process.env.CI || !!process.env.RUNNER_DEBUG,
+
 	// faster video processing
 	videoCompression: false,
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -77,7 +77,9 @@ export default defineConfig({
 
 			// Remove container after run
 			on('after:run', () => {
-				stopNextcloud()
+				if (!process.env.CI) {
+					stopNextcloud()
+				}
 			})
 
 			// Before the browser launches

--- a/cypress/e2e/filesUtils.ts
+++ b/cypress/e2e/filesUtils.ts
@@ -40,7 +40,12 @@ export const triggerActionForFile = (filename: string, actionId: string) => {
 }
 
 export function renameFile(fileName: string, newName: string) {
+	// The file must exist and the preview loaded as it locks the file
 	getRowForFile(fileName)
+		.should('be.visible')
+		.find('.files-list__row-icon-preview--loaded')
+		.should('exist')
+
 	triggerActionForFile(fileName, 'rename')
 
 	// intercept the move so we can wait for it

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -71,6 +71,7 @@ describe('Check activity listing in the sidebar', { testIsolation: true }, () =>
 
 	it('Has comment activity', () => {
 		addComment('welcome.txt', 'A comment')
+		cy.visit('/apps/files')
 
 		showActivityTab('welcome.txt')
 		cy.get('.comments-activity').first().should('contains.text', 'A comment')

--- a/cypress/e2e/sidebarUtils.ts
+++ b/cypress/e2e/sidebarUtils.ts
@@ -26,9 +26,11 @@ export function showActivityTab(fileName: string) {
 	cy.intercept('GET', '/ocs/v2.php/apps/activity/api/v2/activity/filter**').as('getActivities')
 
 	showSidebarForFile(fileName)
+
+	// {force: true} as it might be hidden behind toasts
 	cy.get('#app-sidebar-vue')
 		.findByRole('tab', { name: 'Activity' })
-		.click()
+		.click({ force: true })
 
 	cy.get('#app-sidebar-vue')
 		.findByRole('tabpanel', { name: 'Activity' })


### PR DESCRIPTION
Fixes:
* Force click on activity tab, as it could be under a toast
* Wait for preview to be generated, to ensure the file is not locked by preview generation
* Reload the page after adding a comment (as is done for tags)
* Don't stop containers on CI to extract nextcloud logs
* Record video when job runs in debug mode
* Reduce containers from 3 -> 2 as we only have 2 suites anyway (IMO it can also be just 1...)