### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,12 +20,6 @@ require_once __DIR__ . '/../../../tests/autoload.php';
 
 Server::get(IAppManager::class)->loadApp('activity');
 
-// Fix for "Autoload path not allowed: .../files/lib/activity.php"
-Server::get(IAppManager::class)->loadApp('files');
-
-// Fix for "Autoload path not allowed: .../files_sharing/lib/activity.php"
-Server::get(IAppManager::class)->loadApp('files_sharing');
-
 if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,45 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * @copyright Copyright (c) 2016, ownCloud, Inc.
- *
- * @author Joas Schilling <coding@schilljs.com>
- * @author Jörn Friedrich Dreyer <jfd@butonic.de>
- *
- * @license AGPL-3.0
- *
- * This code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License, version 3,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
 
-// Fix for "Autoload path not allowed: .../tests/lib/testcase.php"
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-
-// Fix for "Autoload path not allowed: .../activity/tests/testcase.php"
-\OC_App::loadApp('activity');
+Server::get(IAppManager::class)->loadApp('activity');
 
 // Fix for "Autoload path not allowed: .../files/lib/activity.php"
-\OC_App::loadApp('files');
+Server::get(IAppManager::class)->loadApp('files');
 
 // Fix for "Autoload path not allowed: .../files_sharing/lib/activity.php"
-\OC_App::loadApp('files_sharing');
+Server::get(IAppManager::class)->loadApp('files_sharing');
 
-if (!class_exists('\PHPUnit\Framework\TestCase')) {
+if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,5 +29,3 @@ Server::get(IAppManager::class)->loadApp('files_sharing');
 if (!class_exists(TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
-
-OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.