### PR TITLE
fix(FilesHooks): Catch all exceptions when looking up unrelated users

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -1398,7 +1398,7 @@ class FilesHooks {
 				if ($node->isReadable()) {
 					continue; // overkill ? as rootFolder->get() would throw an exception if file is not available
 				}
-			} catch (\Exception $e) {
+			} catch (\Throwable $e) {
 			}
 
 			$filteredUsers[] = $userId;


### PR DESCRIPTION
This will catch "Undefined array key" exceptions from above `$cachedPath[$userId]`.

Fix: https://github.com/nextcloud/groupfolders/issues/3680