### PR TITLE
fix(dashboard): enable rounded icons

### DIFF
--- a/lib/Dashboard/ActivityWidget.php
+++ b/lib/Dashboard/ActivityWidget.php
@@ -15,16 +15,18 @@ use OCA\Activity\UserSettings;
 use OCP\Dashboard\IAPIWidget;
 use OCP\Dashboard\IButtonWidget;
 use OCP\Dashboard\IIconWidget;
+use OCP\Dashboard\IOptionWidget;
 use OCP\Dashboard\IReloadableWidget;
 use OCP\Dashboard\Model\WidgetButton;
 use OCP\Dashboard\Model\WidgetItem;
 use OCP\Dashboard\Model\WidgetItems;
+use OCP\Dashboard\Model\WidgetOptions;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Util;
 
-class ActivityWidget implements IAPIWidget, IButtonWidget, IIconWidget, IReloadableWidget {
+class ActivityWidget implements IAPIWidget, IButtonWidget, IIconWidget, IReloadableWidget, IOptionWidget {
 	private Data $data;
 	private IL10N $l10n;
 	private GroupHelper $helper;
@@ -201,5 +203,13 @@ class ActivityWidget implements IAPIWidget, IButtonWidget, IIconWidget, IReloada
 	#[\Override]
 	public function getReloadInterval(): int {
 		return 30;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+	public function getWidgetOptions(): WidgetOptions {
+		return new WidgetOptions(true);
 	}
 }


### PR DESCRIPTION
Avatars are not round in the recent activity widget.

| Before | After | 
| --- | --- |
| <img width="137" height="651" alt="Bildschirmfoto vom 2025-08-11 19-31-30" src="https://github.com/user-attachments/assets/b42e4305-c0df-413e-a3e2-1f916b1ac048" /> | <img width="198" height="655" alt="Bildschirmfoto vom 2025-08-11 19-29-20" src="https://github.com/user-attachments/assets/4d5d6473-951e-4344-89da-9a18ca36dc19" /> |
