### PR TITLE
fix(emails): catch server connection exceptions

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -63,10 +63,10 @@ class MailQueueHandler {
 	/**
 	 * Send an email to {$limit} users
 	 *
-	 * @param $limit Number of users we want to send an email to
-	 * @param $sendTime The latest send time
-	 * @param $forceSending Ignores latest send and just sends all emails
-	 * @param $restrictEmails null or one of UserSettings::EMAIL_SEND_*, will overwrite force send
+	 * @param int $limit Number of users we want to send an email to
+	 * @param int $sendTime The latest send time
+	 * @param bool $forceSending Ignores latest send and just sends all emails
+	 * @param int|null $restrictEmails null or one of UserSettings::EMAIL_SEND_*, will overwrite force send
 	 * @return int Number of users we sent an email to
 	 */
 	public function sendEmails(int $limit, int $sendTime, bool $forceSending = false, ?int $restrictEmails = null): int {
@@ -93,7 +93,13 @@ class MailQueueHandler {
 				continue;
 			}
 
-			$userObject = $this->userManager->get($user);
+			try {
+				$userObject = $this->userManager->get($user);
+			} catch (\Exception $e) {
+				$this->logger->error('An error happened while trying to find ' . $user . ', skipping', ['exception' => $e]);
+				continue;
+			}
+
 			$email = $userObject ? $userObject->getEMailAddress() : '';
 			if (empty($email)) {
 				// The user did not setup an email address


### PR DESCRIPTION
Fixes https://github.com/nextcloud/activity/issues/2120

Handle the case where the user backend isn't reachable.

Currently, the exception breaks hard when the user backend throws an `\Exception` and thus, already sent activity emails don't get deleted and are resent on the next batch.

Catching the exception and logging it instead at least doesn't lead to multiple emails being sent.

