### PR TITLE
fix(notifications): Require absolute links for support of desktop and mobile clients

### DIFF
--- a/lib/NotificationGenerator.php
+++ b/lib/NotificationGenerator.php
@@ -31,6 +31,14 @@ class NotificationGenerator implements INotifier {
 	) {
 	}
 
+	private function sanitizeUrl(string $url): string {
+		if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
+			return $url;
+		}
+
+		return '';
+	}
+
 	public function deferNotifications(): bool {
 		return $this->notificationManager->defer();
 	}
@@ -68,8 +76,9 @@ class NotificationGenerator implements INotifier {
 			$notification->setMessage($event->getMessage(), $event->getMessageParameters());
 		}
 
-		if ($event->getLink()) {
-			$notification->setLink($event->getLink());
+		$link = $event->getLink() ? $this->sanitizeUrl($event->getLink()) : '';
+		if ($link !== '') {
+			$notification->setLink($link);
 		}
 
 		return $notification;
@@ -127,8 +136,9 @@ class NotificationGenerator implements INotifier {
 		$notification->setRichSubject($event->getRichSubject(), $event->getRichSubjectParameters());
 		$notification->setParsedSubject($event->getParsedSubject());
 
-		if ($event->getIcon()) {
-			$notification->setIcon($event->getIcon());
+		$icon = $event->getIcon() ? $this->sanitizeUrl($event->getIcon()) : '';
+		if ($icon !== '') {
+			$notification->setIcon($icon);
 		}
 
 		if ($event->getRichMessage()) {


### PR DESCRIPTION
To align with the stricter validation introduced in nextcloud/server#59606.

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>