### PR TITLE
fix(security): escape link URLs in activity email templates

### DIFF
--- a/lib/DigestSender.php
+++ b/lib/DigestSender.php
@@ -188,7 +188,7 @@ class DigestSender {
 			$andMoreText = $l10n->n('and %n more…', 'and %n more…', $skippedCount);
 			$url = $this->urlGenerator->linkToRouteAbsolute('activity.Activities.showList', [ 'filter' => 'all' ]);
 			$template->addBodyListItem(
-				'<a href="' . $url . '">' . htmlspecialchars($andMoreText) . '</a>',
+				'<a href="' . htmlspecialchars($url) . '">' . htmlspecialchars($andMoreText) . '</a>',
 				plainText: $andMoreText,
 			);
 		}
@@ -235,7 +235,7 @@ class DigestSender {
 			}
 
 			if (isset($parameter['link'])) {
-				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
+				$replacements[] = '<a href="' . htmlspecialchars((string)$parameter['link']) . '">' . htmlspecialchars($replacement) . '</a>';
 			} else {
 				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
 			}

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -331,7 +331,7 @@ class MailQueueHandler {
 		$template->addHeader();
 		$template->addHeading($l->t('Hello %s', [$user->getDisplayName()]), $l->t('Hello %s,', [$user->getDisplayName()]));
 
-		$homeLink = '<a href="' . $this->urlGenerator->getAbsoluteURL('/') . '">' . htmlspecialchars($this->getSenderData('name')) . '</a>';
+		$homeLink = '<a href="' . htmlspecialchars($this->urlGenerator->getAbsoluteURL('/')) . '">' . htmlspecialchars($this->getSenderData('name')) . '</a>';
 		$template->addBodyText(
 			$l->t('There was some activity at %s', [$homeLink]),
 			$l->t('There was some activity at %s', [$this->urlGenerator->getAbsoluteURL('/')])
@@ -394,7 +394,7 @@ class MailQueueHandler {
 			}
 
 			if (isset($parameter['link'])) {
-				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
+				$replacements[] = '<a href="' . htmlspecialchars((string)$parameter['link']) . '">' . htmlspecialchars($replacement) . '</a>';
 			} else {
 				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
 			}

--- a/tests/DigestSenderTest.php
+++ b/tests/DigestSenderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Activity\Tests;
+
+use OCA\Activity\Data;
+use OCA\Activity\DigestSender;
+use OCA\Activity\GroupHelper;
+use OCA\Activity\UserSettings;
+use OCP\Activity\IEvent;
+use OCP\Activity\IManager;
+use OCP\Defaults;
+use OCP\IConfig;
+use OCP\IDateTimeFormatter;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Mail\IMailer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LoggerInterface;
+
+class DigestSenderTest extends TestCase {
+	private DigestSender $digestSender;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->digestSender = new DigestSender(
+			$this->createMock(IConfig::class),
+			$this->createMock(Data::class),
+			$this->createMock(UserSettings::class),
+			$this->createMock(GroupHelper::class),
+			$this->createMock(IMailer::class),
+			$this->createMock(IManager::class),
+			$this->createMock(IUserManager::class),
+			$this->createMock(IURLGenerator::class),
+			$this->createMock(Defaults::class),
+			$this->createMock(IFactory::class),
+			$this->createMock(IDateTimeFormatter::class),
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	public static function provideGetHTMLSubjectData(): array {
+		return [
+			'no rich subject escapes parsed subject' => [
+				'', 'Hello <World>', [],
+				'Hello &lt;World&gt;',
+			],
+			'linked parameter renders anchor' => [
+				'File {file} was shared', '',
+				['file' => ['type' => 'file', 'path' => 'photo.jpg', 'name' => 'photo.jpg', 'link' => 'https://cloud.example.com/f/123']],
+				'File <a href="https://cloud.example.com/f/123">photo.jpg</a> was shared',
+			],
+			'double-quote in link is escaped' => [
+				'File {file} was shared', '',
+				['file' => ['type' => 'file', 'path' => 'photo.jpg', 'name' => 'photo.jpg', 'link' => 'https://cloud.example.com/f/123"onmouseover="alert(1)']],
+				'File <a href="https://cloud.example.com/f/123&quot;onmouseover=&quot;alert(1)">photo.jpg</a> was shared',
+			],
+			'parameter without link uses strong tag' => [
+				'File {file} was shared', '',
+				['file' => ['type' => 'file', 'path' => 'photo.jpg', 'name' => 'photo.jpg']],
+				'File <strong>photo.jpg</strong> was shared',
+			],
+		];
+	}
+
+	#[DataProvider('provideGetHTMLSubjectData')]
+	public function testGetHTMLSubject(string $richSubject, string $parsedSubject, array $richParams, string $expected): void {
+		$event = $this->createMock(IEvent::class);
+		$event->method('getRichSubject')->willReturn($richSubject);
+		$event->method('getParsedSubject')->willReturn($parsedSubject);
+		$event->method('getRichSubjectParameters')->willReturn($richParams);
+
+		$result = self::invokePrivate($this->digestSender, 'getHTMLSubject', [$event]);
+		$this->assertSame($expected, $result);
+	}
+}

--- a/tests/MailQueueHandlerTest.php
+++ b/tests/MailQueueHandlerTest.php
@@ -375,6 +375,41 @@ class MailQueueHandlerTest extends TestCase {
 	 * @param int $maxTime
 	 * @param string $explain
 	 */
+	public static function provideGetHTMLSubjectData(): array {
+		return [
+			'no rich subject escapes parsed subject' => [
+				'', 'Hello <World>', [],
+				'Hello &lt;World&gt;',
+			],
+			'linked parameter renders anchor' => [
+				'File {file} was shared', '',
+				['file' => ['type' => 'file', 'path' => 'photo.jpg', 'name' => 'photo.jpg', 'link' => 'https://cloud.example.com/f/123']],
+				'File <a href="https://cloud.example.com/f/123">photo.jpg</a> was shared',
+			],
+			'double-quote in link is escaped' => [
+				'File {file} was shared', '',
+				['file' => ['type' => 'file', 'path' => 'photo.jpg', 'name' => 'photo.jpg', 'link' => 'https://cloud.example.com/f/123"onmouseover="alert(1)']],
+				'File <a href="https://cloud.example.com/f/123&quot;onmouseover=&quot;alert(1)">photo.jpg</a> was shared',
+			],
+			'parameter without link uses strong tag' => [
+				'File {file} was shared', '',
+				['file' => ['type' => 'file', 'path' => 'photo.jpg', 'name' => 'photo.jpg']],
+				'File <strong>photo.jpg</strong> was shared',
+			],
+		];
+	}
+
+	#[DataProvider('provideGetHTMLSubjectData')]
+	public function testGetHTMLSubject(string $richSubject, string $parsedSubject, array $richParams, string $expected): void {
+		$event = $this->createMock(IEvent::class);
+		$event->method('getRichSubject')->willReturn($richSubject);
+		$event->method('getParsedSubject')->willReturn($parsedSubject);
+		$event->method('getRichSubjectParameters')->willReturn($richParams);
+
+		$result = self::invokePrivate($this->mailQueueHandler, 'getHTMLSubject', [$event]);
+		$this->assertSame($expected, $result);
+	}
+
 	protected function assertRemainingMailEntries(array $users, int $maxTime, string $explain): void {
 		foreach ($users as $user) {
 			[$data,] = self::invokePrivate($this->mailQueueHandler, 'getItemsForUser', [$user, $maxTime]);


### PR DESCRIPTION
The activity-digest and queued-mail templates interpolate the `link` attribute of rich-subject parameters and the home URL directly into the `href` of an `<a>` tag without HTML-escaping. Activity providers typically supply internal Nextcloud URLs, but defensive escaping closes a potential `"`-breakout XSS vector should a provider ever expose user-influenced link values.

Wrap the URLs in `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` in:
- DigestSender.php — "and N more" link, rich-subject link parameter
- MailQueueHandler.php — home link, rich-subject link parameter

Translation-string templates (`$l->t('...<a href="%s">...', ...)`) are left as-is: their URLs come exclusively from `linkToRouteAbsolute()`, and escaping inside the gettext source string would force translators to handle escaping for every locale.