### PR TITLE
fix(cypress): exclude screenshot spec from regular PR CI runs

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -38,6 +38,10 @@ export default defineConfig({
 	trashAssetsBeforeRuns: true,
 
 	e2e: {
+		// Exclude the documentation screenshot spec from regular CI runs.
+		// It is run explicitly by the screenshots.yml workflow_dispatch workflow.
+		excludeSpecPattern: '**/screenshots.cy.ts',
+
 		// We've imported your old cypress plugins here.
 		// You may want to clean this up later by importing these.
 		async setupNodeEvents(on, config) {


### PR DESCRIPTION
The screenshots.cy.ts spec is intended for the manual screenshots.yml workflow only. Including it in the default e2e spec pattern caused it to run on every PR, where the reduced app setup (viewer only) triggered a JS crash before any test could start.

excludeSpecPattern is ignored when a spec is passed explicitly, so the screenshots.yml workflow is unaffected.

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>