### PR TITLE
fix(cypress): ensure activity app is enabled and fix file list row se…

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,4 @@
-import { configureNextcloud, startNextcloud, stopNextcloud, waitOnNextcloud } from '@nextcloud/cypress/docker'
+import { configureNextcloud, runOcc, startNextcloud, stopNextcloud, waitOnNextcloud } from '@nextcloud/cypress/docker'
 // eslint-disable-next-line n/no-extraneous-import
 import { defineConfig } from 'cypress'
 
@@ -92,7 +92,9 @@ export default defineConfig({
 			// Setting container's IP as base Url
 			config.baseUrl = `http://${ip}/index.php`
 			await waitOnNextcloud(ip)
-			await configureNextcloud(['viewer'])
+			await configureNextcloud(['viewer', 'activity'])
+			// NC 34+ requires Chrome 142+ but Cypress uses Electron 118 — disable the browser check
+			await runOcc(['config:system:set', 'no_unsupported_browser_warning', '--value', 'true', '--type', 'boolean'])
 			return config
 		},
 	},

--- a/cypress/e2e/filesUtils.ts
+++ b/cypress/e2e/filesUtils.ts
@@ -115,13 +115,16 @@ export function moveFile (fileName: string, dirName: string) {
 }
 
 export function getFileListRow(filename: string) {
-	return cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${CSS.escape(filename)}"]`)
+	return cy.get(`[data-cy-files-list-row-name="${CSS.escape(filename)}"]`)
 }
 
 export function toggleMenuAction(filename: string, action: 'details'|'favorite'|'move-copy'|'rename') {
+	// Wait for the preview to be loaded before interacting — ensures the row has
+	// finished receiving metadata updates (shares, tags, etc.) so that opening the
+	// actions menu won't be interrupted by a Vue re-render.
 	getFileListRow(filename)
-		.find('[data-cy-files-list-row-actions]')
-		.should('be.visible')
+		.find('.files-list__row-icon-preview--loaded')
+		.should('exist')
 
 	getFileListRow(filename)
 		.find('[data-cy-files-list-row-actions]')


### PR DESCRIPTION
…lector for NC 34

- Add 'activity' to configureNextcloud so the app is force-enabled even if the NC 34 Docker image has it disabled after the local code is bind-mounted (which prevents the notifications settings section from rendering and leaves #app-content empty)
- Drop the [data-cy-files-list] parent from getFileListRow, aligning with NC 34's own test helpers which address the same selector

AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>