### PR TITLE
test(cypress): improve e2e test stability

### DIFF
--- a/cypress/e2e/filesUtils.ts
+++ b/cypress/e2e/filesUtils.ts
@@ -130,10 +130,10 @@ export function toggleMenuAction(filename: string, action: 'details'|'favorite'|
 		.find('[data-cy-files-list-row-actions]')
 		.findByRole('button', { name: 'Actions' })
 		.should('be.visible')
-		.click()
+		.click({ force: true })
 
-	cy.get(`[data-cy-files-list-row-action="${CSS.escape(action)}"]`)
+	cy.get(`[data-cy-files-list-row-action="${CSS.escape(action)}"]`, { timeout: 10000 })
 		.should('be.visible')
 		.findByRole('menuitem')
-		.click()
+		.click({ force: true })
 }

--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -19,8 +19,11 @@ describe('Check that user\'s settings survive a reload', () => {
 	})
 
 	it('Form survive a reload', () => {
+		cy.intercept({ method: 'POST', url: '**/activity/settings' }).as('apiCall')
+
 		cy.get("#app-content input[type='checkbox']").uncheck({ force: true })
 		cy.get("#app-content input[type='checkbox']").should('not.be.checked')
+		cy.wait('@apiCall')
 
 		cy.reload()
 
@@ -34,6 +37,7 @@ describe('Check that user\'s settings survive a reload', () => {
 		cy.get('#calendar_notification').check({ force: true })
 		cy.get('#personal_settings_email').check({ force: true })
 		cy.get('#personal_settings_notification').check({ force: true })
+		cy.wait('@apiCall')
 		cy.reload()
 
 		cy.get('#file_changed_email').should('not.be.checked')

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -38,13 +38,9 @@ describe('Check activity listing in the sidebar', { testIsolation: true }, () =>
 
 	it('Has share activity', () => {
 		createPublicShare('welcome.txt')
-		cy.intercept('PROPFIND', /\/remote\.php\/dav\/files\//).as('loadFiles')
-		cy.visit('/apps/files')
-		// Wait for the file list PROPFIND to complete — share types are returned as
-		// WebDAV properties in this response, so the row is stable once it resolves.
-		cy.wait('@loadFiles')
-		getFileListRow('welcome.txt').should('be.visible')
-
+		// No re-navigation needed — createPublicShare already waits for the share API
+		// and closes the sidebar, so the activity is recorded and the page is stable.
+		// Re-navigating triggers an async share-badge update that closes the Actions menu.
 		showActivityTab('welcome.txt')
 		cy.get('.activity-entry').first().should('contains.text', 'Shared as public link')
 	})

--- a/cypress/e2e/sidebar.cy.ts
+++ b/cypress/e2e/sidebar.cy.ts
@@ -38,7 +38,11 @@ describe('Check activity listing in the sidebar', { testIsolation: true }, () =>
 
 	it('Has share activity', () => {
 		createPublicShare('welcome.txt')
+		cy.intercept('PROPFIND', /\/remote\.php\/dav\/files\//).as('loadFiles')
 		cy.visit('/apps/files')
+		// Wait for the file list PROPFIND to complete — share types are returned as
+		// WebDAV properties in this response, so the row is stable once it resolves.
+		cy.wait('@loadFiles')
 		getFileListRow('welcome.txt').should('be.visible')
 
 		showActivityTab('welcome.txt')

--- a/cypress/e2e/sidebarUtils.ts
+++ b/cypress/e2e/sidebarUtils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { toggleMenuAction, triggerActionForFile } from './filesUtils.ts'
+import { getRowForFile, toggleMenuAction, triggerActionForFile } from './filesUtils.ts'
 
 function showSidebarForFile(fileName: string) {
 	toggleMenuAction(fileName, 'details')
@@ -60,8 +60,6 @@ export function toggleFavorite(fileName: string) {
  * @param fileName Name of the file to share
  */
 export function createPublicShare(fileName: string) {
-	cy.intercept('POST', '/ocs/v2.php/apps/files_sharing/api/v1/shares').as('createPublicShare')
-
 	showSidebarForFile(fileName)
 	cy.get('#app-sidebar-vue')
 		.findByRole('tab', { name: 'Sharing' })
@@ -77,8 +75,6 @@ export function createPublicShare(fileName: string) {
 
 	cy.wait('@createShare')
 	closeSidebar()
-
-	cy.wait('@createPublicShare')
 }
 
 /**
@@ -88,6 +84,11 @@ export function createPublicShare(fileName: string) {
  * @param newTag - The new tag
  */
 export function addTag(fileName: string, newTag: string) {
+	getRowForFile(fileName)
+		.should('be.visible')
+		.find('.files-list__row-icon-preview--loaded')
+		.should('exist')
+
 	triggerActionForFile(fileName, 'systemtags:bulk')
 
 	cy.intercept('POST', '/remote.php/dav/systemtags').as('createTag')


### PR DESCRIPTION
**toggleMenuAction** (`filesUtils.ts`): add `{ force: true }` to both clicks and `{ timeout: 10000 }` on the action element lookup to survive Vue re-renders triggered by async metadata updates (e.g. share badge loading after file list render).

**"Has share activity"** (`sidebar.cy.ts`): remove the `cy.visit('/apps/files')` re-navigation after `createPublicShare`. The share is already recorded server-side (waited on via `@createShare`) and the sidebar is already closed, so `showActivityTab` can be called directly. Re-navigating caused NC to async-load the share badge on the file row, which triggered a Vue re-render that closed the Actions menu before the `details` entry could be clicked — failing even with a 10s timeout.

**"Form survive a reload"** (`settings.cy.ts`): add `cy.intercept` + `cy.wait('@apiCall')` before each `cy.reload()`, matching the pattern already used by the other two tests in this file.

**`createPublicShare`** (`sidebarUtils.ts`): remove duplicate intercept alias for the same POST endpoint and the redundant trailing `cy.wait('@createPublicShare')`.

**`addTag`** (`sidebarUtils.ts`): wait for `.files-list__row-icon-preview--loaded` before opening the action menu, consistent with `renameFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)