### PR TITLE
fix(MailQueueHandler): check enable_email toggle before sending queued emails

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IDBConnection;
@@ -117,6 +118,7 @@ class Application extends App implements IBootstrap {
 				$c->get(IFactory::class),
 				$c->get(IManager::class),
 				$c->get(IValidator::class),
+				$c->get(IAppConfig::class),
 				$c->get(IConfig::class),
 				$c->get(LoggerInterface::class),
 				$c->get(Data::class),

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -11,6 +11,7 @@ use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Defaults;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IDBConnection;
@@ -51,6 +52,7 @@ class MailQueueHandler {
 		protected IFactory $lFactory,
 		protected IManager $activityManager,
 		protected IValidator $richObjectValidator,
+		protected IAppConfig $appConfig,
 		protected IConfig $config,
 		protected LoggerInterface $logger,
 		protected Data $data,
@@ -70,6 +72,10 @@ class MailQueueHandler {
 	 * @return int Number of users we sent an email to
 	 */
 	public function sendEmails(int $limit, int $sendTime, bool $forceSending = false, ?int $restrictEmails = null): int {
+		if (!$this->appConfig->getValueBool('activity', 'enable_email', true)) {
+			return 0;
+		}
+
 		// Get all users which should receive an email
 		$affectedUsers = $this->getAffectedUsers($limit, $sendTime, $forceSending, $restrictEmails);
 		if (empty($affectedUsers)) {

--- a/tests/MailQueueHandlerTest.php
+++ b/tests/MailQueueHandlerTest.php
@@ -34,6 +34,7 @@ use OCA\Activity\MailQueueHandler;
 use OCA\Activity\UserSettings;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IDBConnection;
@@ -65,6 +66,7 @@ class MailQueueHandlerTest extends TestCase {
 	protected IFactory&MockObject $lFactory;
 	protected IManager&MockObject $activityManager;
 	protected IValidator&MockObject $richObjectValidator;
+	protected IAppConfig&MockObject $appConfig;
 	protected IConfig&MockObject $config;
 	protected MockObject&LoggerInterface $logger;
 
@@ -81,6 +83,7 @@ class MailQueueHandlerTest extends TestCase {
 		$app = self::getUniqueID('MailQueueHandlerTest', 10);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->lFactory = $this->createMock(IFactory::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->dateTimeFormatter = $this->createMock(IDateTimeFormatter::class);
@@ -141,6 +144,7 @@ class MailQueueHandlerTest extends TestCase {
 			$this->lFactory,
 			$this->activityManager,
 			$this->richObjectValidator,
+			$this->appConfig,
 			$this->config,
 			$this->logger,
 			$this->data,
@@ -300,6 +304,10 @@ class MailQueueHandlerTest extends TestCase {
 	public function testSendEmailsDeletesQueueOnMailerFailure(): void {
 		$maxTime = 200;
 
+		$this->appConfig->method('getValueBool')
+			->with('activity', 'enable_email', true)
+			->willReturn(true);
+
 		$template = $this->createMock(IEMailTemplate::class);
 		$this->mailer->method('createEMailTemplate')
 			->willReturn($template);
@@ -340,6 +348,10 @@ class MailQueueHandlerTest extends TestCase {
 	public function testSendEmailsDeletesQueueOnSendReturnFalse(): void {
 		$maxTime = 200;
 
+		$this->appConfig->method('getValueBool')
+			->with('activity', 'enable_email', true)
+			->willReturn(true);
+
 		$template = $this->createMock(IEMailTemplate::class);
 		$this->mailer->method('createEMailTemplate')
 			->willReturn($template);
@@ -367,6 +379,27 @@ class MailQueueHandlerTest extends TestCase {
 		foreach (['user1', 'user2', 'user3'] as $user) {
 			[$data,] = self::invokePrivate($this->mailQueueHandler, 'getItemsForUser', [$user, $maxTime]);
 			$this->assertEmpty($data, "Queue entries for $user should be removed after sendEmailToUser returns false to prevent duplicate notifications");
+		}
+	}
+
+	public function testSendEmailsSkipsWhenAdminEmailDisabled(): void {
+		$maxTime = 200;
+
+		$this->appConfig->method('getValueBool')
+			->with('activity', 'enable_email', true)
+			->willReturn(false);
+
+		$this->mailer->expects($this->never())
+			->method('send');
+
+		$result = $this->mailQueueHandler->sendEmails(3, $maxTime);
+
+		$this->assertSame(0, $result);
+
+		// Queue must be untouched so emails can be sent if admin re-enables the toggle
+		foreach (['user1', 'user2', 'user3'] as $user) {
+			[$data,] = self::invokePrivate($this->mailQueueHandler, 'getItemsForUser', [$user, $maxTime]);
+			$this->assertNotEmpty($data, "Queue entries for $user must survive when email is globally disabled");
 		}
 	}
 


### PR DESCRIPTION
## Summary

The admin **Enable notification emails** toggle was only checked when *queuing* new emails (`Consumer::receive()` / `bulkReceive()`). The `MailQueueHandler::sendEmails()` background job that actually delivers emails had no knowledge of the toggle and would send all queued entries regardless.

This means: if emails were already sitting in `oc_activity_mq` when an admin disabled the toggle, they would still be sent on the next background job run.

The fix adds an early-return guard at the top of `sendEmails()`, consistent with the checks already in `UserSettings::getUserSetting()` and `filterUsersBySetting()`. The queue is intentionally left intact — if the admin re-enables emails, pending notifications can still be delivered.

Related to #2562 (which fixed the same missing check in `bulkReceive()`).

## Test plan

- [x] `composer test:unit` passes (327 tests)
- [x] New test `testSendEmailsSkipsWhenAdminEmailDisabled` verifies: return value is 0, mailer is never called, queue entries survive
- [x] Backport to stable33

🤖 Generated with [Claude Code](https://claude.com/claude-code)