### PR TITLE
refactor: flatten nesting with early returns

### DIFF
--- a/lib/Data.php
+++ b/lib/Data.php
@@ -324,35 +324,38 @@ class Data {
 	 * @throws \OutOfBoundsException If $since is not owned by $user
 	 */
 	protected function setOffsetFromSince(IQueryBuilder $query, $user, $since, $sort) {
-		if ($since) {
-			$queryBuilder = $this->connection->getQueryBuilder();
-			$queryBuilder->select(['affecteduser', 'timestamp'])
-				->from('activity')
-				->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter((int)$since)));
-			$result = $queryBuilder->executeQuery();
-			$activity = $result->fetch();
-			$result->closeCursor();
-
-			if ($activity) {
-				if ($activity['affecteduser'] !== $user) {
-					throw new \OutOfBoundsException('Invalid since', 2);
-				}
-				$timestamp = (int)$activity['timestamp'];
-
-				if ($sort === 'DESC') {
-					$query->andWhere($query->expr()->lte('timestamp', $query->createNamedParameter($timestamp)));
-					$query->andWhere($query->expr()->lt('activity_id', $query->createNamedParameter($since)));
-				} else {
-					$query->andWhere($query->expr()->gte('timestamp', $query->createNamedParameter($timestamp)));
-					$query->andWhere($query->expr()->gt('activity_id', $query->createNamedParameter($since)));
-				}
-				return [];
-			}
+		if (!$since) {
+			return $this->getFirstKnownActivityHeader($user, $sort);
 		}
 
-		/**
-		 * Couldn't find the since, so find the oldest one and set the header
-		 */
+		$queryBuilder = $this->connection->getQueryBuilder();
+		$queryBuilder->select(['affecteduser', 'timestamp'])
+			->from('activity')
+			->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter((int)$since)));
+		$result = $queryBuilder->executeQuery();
+		$activity = $result->fetch();
+		$result->closeCursor();
+
+		if (!$activity) {
+			return $this->getFirstKnownActivityHeader($user, $sort);
+		}
+
+		if ($activity['affecteduser'] !== $user) {
+			throw new \OutOfBoundsException('Invalid since', 2);
+		}
+
+		$timestamp = (int)$activity['timestamp'];
+		if ($sort === 'DESC') {
+			$query->andWhere($query->expr()->lte('timestamp', $query->createNamedParameter($timestamp)));
+			$query->andWhere($query->expr()->lt('activity_id', $query->createNamedParameter($since)));
+		} else {
+			$query->andWhere($query->expr()->gte('timestamp', $query->createNamedParameter($timestamp)));
+			$query->andWhere($query->expr()->gt('activity_id', $query->createNamedParameter($since)));
+		}
+		return [];
+	}
+
+	private function getFirstKnownActivityHeader(string $user, string $sort): array {
 		$fetchQuery = $this->connection->getQueryBuilder();
 		$fetchQuery->select('activity_id')
 			->from('activity')
@@ -364,11 +367,8 @@ class Data {
 		$result->closeCursor();
 
 		if ($activity !== false) {
-			return [
-				'X-Activity-First-Known' => (int)$activity['activity_id'],
-			];
+			return ['X-Activity-First-Known' => (int)$activity['activity_id']];
 		}
-
 		return [];
 	}
 

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -158,16 +158,7 @@ class MailQueueHandler {
 			} elseif ($restrictEmails === UserSettings::EMAIL_SEND_ASAP) {
 				$query->where($query->expr()->eq('amq_timestamp', 'amq_latest_send'));
 			}
-
-			$result = $query->executeQuery();
-
-			$affectedUsers = [];
-			while ($row = $result->fetch()) {
-				$affectedUsers[] = $row['amq_affecteduser'];
-			}
-			$result->closeCursor();
-
-			return $affectedUsers;
+			return $this->fetchAffectedUsers($query);
 		}
 
 		if ($forceSending) {
@@ -176,14 +167,16 @@ class MailQueueHandler {
 			$query->where($query->expr()->lt('amq_latest_send', $query->createNamedParameter($latestSend)));
 		}
 
-		$result = $query->executeQuery();
+		return $this->fetchAffectedUsers($query);
+	}
 
+	private function fetchAffectedUsers(IQueryBuilder $query): array {
+		$result = $query->executeQuery();
 		$affectedUsers = [];
 		while ($row = $result->fetch()) {
 			$affectedUsers[] = $row['amq_affecteduser'];
 		}
 		$result->closeCursor();
-
 		return $affectedUsers;
 	}
 


### PR DESCRIPTION
## Summary

- `Data::setOffsetFromSince()`: inverted the two nested guard conditions into early returns, and extracted the repeated fallback DB fetch into a private `getFirstKnownActivityHeader()` helper — reducing nesting from 3 levels to 1
- `MailQueueHandler::getAffectedUsers()`: added an early return in the `$restrictEmails !== null` branch and extracted the duplicated result-fetching loop into a private `fetchAffectedUsers()` helper, removing ~10 lines of copy-pasted code

No behaviour changes. All existing tests pass.

## Test plan

- [x] `testSetOffsetFromSince` (15 tests, 106 assertions) — green
- [x] `MailQueueHandlerTest` (10 tests, 93 assertions) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)