### PR TITLE
refactor: flatten nesting in CurrentUser::getCloudId() with early return

### DIFF
--- a/lib/CurrentUser.php
+++ b/lib/CurrentUser.php
@@ -90,13 +90,15 @@ class CurrentUser {
 	 * @return string|null
 	 */
 	public function getCloudId() {
-		if ($this->cloudId === false) {
-			$user = $this->userSession->getUser();
-			if ($user instanceof IUser) {
-				$this->cloudId = (string)$user->getCloudId();
-			} else {
-				$this->cloudId = $this->getCloudIDFromToken();
-			}
+		if ($this->cloudId !== false) {
+			return $this->cloudId;
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser) {
+			$this->cloudId = (string)$user->getCloudId();
+		} else {
+			$this->cloudId = $this->getCloudIDFromToken();
 		}
 
 		return $this->cloudId;

--- a/tests/CurrentUserTest.php
+++ b/tests/CurrentUserTest.php
@@ -194,4 +194,33 @@ class CurrentUserTest extends TestCase {
 
 		$this->assertSame($expected, self::invokePrivate($instance, 'getCloudIDFromToken'));
 	}
+
+	public function testGetCloudIdCached(): void {
+		$instance = $this->getInstance();
+		self::invokePrivate($instance, 'cloudId', ['cached-cloud-id']);
+
+		$this->userSession->expects($this->never())->method('getUser');
+
+		$this->assertSame('cached-cloud-id', $instance->getCloudId());
+	}
+
+	public function testGetCloudIdFromUser(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getCloudId')->willReturn('user@cloud.example.com');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$instance = $this->getInstance();
+
+		$this->assertSame('user@cloud.example.com', $instance->getCloudId());
+		$this->assertSame('user@cloud.example.com', $instance->getCloudId(), 'second call returns cached value');
+	}
+
+	public function testGetCloudIdFallsBackToToken(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$instance = $this->getInstance(['getCloudIDFromToken']);
+		$instance->method('getCloudIDFromToken')->willReturn('token-cloud-id');
+
+		$this->assertSame('token-cloud-id', $instance->getCloudId());
+	}
 }


### PR DESCRIPTION
## Summary

Inverts the `$cloudId !== false` cache guard in `CurrentUser::getCloudId()` into an early return, removing one level of nesting from the fetch path.

Adds three tests that were missing: cache hit (no session call), session-user path, and token-fallback path.

## Test plan

- [x] New `testGetCloudId*` tests (3 tests) — green
- [x] Full `CurrentUserTest` suite — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)