### PR TITLE
refactor: clarify fileCreate() condition by making the specific case explicit

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -82,10 +82,10 @@ class FilesHooks {
 			return;
 		}
 
-		if ($this->currentUser->getUserIdentifier() !== '' || !$this->currentUser->isPublicShareToken()) {
-			$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_CREATED, 'created_self', 'created_by');
-		} else {
+		if ($this->currentUser->getUserIdentifier() === '' && $this->currentUser->isPublicShareToken()) {
 			$this->addNotificationsForFileAction($path, Files_Sharing::TYPE_PUBLIC_UPLOAD, '', 'created_public');
+		} else {
+			$this->addNotificationsForFileAction($path, Files::TYPE_SHARE_CREATED, 'created_self', 'created_by');
 		}
 	}
 

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -171,6 +171,8 @@ class FilesHooksTest extends TestCase {
 			['user', false, 'created_self', 'created_by', Files::TYPE_SHARE_CREATED],
 			['', true, '', 'created_public', Files_Sharing::TYPE_PUBLIC_UPLOAD],
 			['', false, 'created_self', 'created_by', Files::TYPE_SHARE_CREATED],
+			// logged-in user uploading to a public share link → treated as regular upload
+			['user', true, 'created_self', 'created_by', Files::TYPE_SHARE_CREATED],
 		];
 	}
 


### PR DESCRIPTION
## Summary

The original condition in `FilesHooks::fileCreate()` used a double-negative (De Morgan) form:

```php
// Before — hard to parse: "unless identifier is empty AND it's a public token"
if ($this->currentUser->getUserIdentifier() !== '' || !$this->currentUser->isPublicShareToken()) {
    // regular upload
} else {
    // public upload
}
```

Rewritten as a direct positive check, with the specific case (public upload) as the `if`-branch:

```php
// After — reads naturally
if ($this->currentUser->getUserIdentifier() === '' && $this->currentUser->isPublicShareToken()) {
    // public upload
} else {
    // regular upload
}
```

Also adds the missing fourth test case: a non-empty identifier combined with `isPublicShareToken=true` (a logged-in user uploading to a public share link) → treated as a regular upload.

No behaviour change.

## Test plan

- [x] All `testFileCreate` cases (4 data rows × 2 root tests = 6 assertions) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)