### PR TITLE
refactor: replace magic batch-time seconds with named constants

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -150,11 +150,11 @@ class MailQueueHandler {
 
 		if ($restrictEmails !== null) {
 			if ($restrictEmails === UserSettings::EMAIL_SEND_HOURLY) {
-				$query->where($query->expr()->eq('amq_timestamp', $query->func()->subtract('amq_latest_send', $query->expr()->literal(3600))));
+				$query->where($query->expr()->eq('amq_timestamp', $query->func()->subtract('amq_latest_send', $query->expr()->literal(UserSettings::BATCH_TIME_HOURLY))));
 			} elseif ($restrictEmails === UserSettings::EMAIL_SEND_DAILY) {
-				$query->where($query->expr()->eq('amq_timestamp', $query->func()->subtract('amq_latest_send', $query->expr()->literal(3600 * 24))));
+				$query->where($query->expr()->eq('amq_timestamp', $query->func()->subtract('amq_latest_send', $query->expr()->literal(UserSettings::BATCH_TIME_DAILY))));
 			} elseif ($restrictEmails === UserSettings::EMAIL_SEND_WEEKLY) {
-				$query->where($query->expr()->eq('amq_timestamp', $query->func()->subtract('amq_latest_send', $query->expr()->literal(3600 * 24 * 7))));
+				$query->where($query->expr()->eq('amq_timestamp', $query->func()->subtract('amq_latest_send', $query->expr()->literal(UserSettings::BATCH_TIME_WEEKLY))));
 			} elseif ($restrictEmails === UserSettings::EMAIL_SEND_ASAP) {
 				$query->where($query->expr()->eq('amq_timestamp', 'amq_latest_send'));
 			}

--- a/lib/UserSettings.php
+++ b/lib/UserSettings.php
@@ -26,6 +26,10 @@ class UserSettings {
 	public const EMAIL_SEND_WEEKLY = 2;
 	public const EMAIL_SEND_ASAP = 3;
 
+	public const BATCH_TIME_HOURLY = 3600;
+	public const BATCH_TIME_DAILY = 3600 * 24;
+	public const BATCH_TIME_WEEKLY = 3600 * 24 * 7;
+
 	/**
 	 * @param IManager $manager
 	 * @param IConfig $config
@@ -109,7 +113,7 @@ class UserSettings {
 	protected function getDefaultSetting($method, $type) {
 		if ($method === 'setting') {
 			if ($type === 'batchtime') {
-				return 3600;
+				return self::BATCH_TIME_HOURLY;
 			}
 
 			if ($type === 'self') {


### PR DESCRIPTION
## Summary

Adds `BATCH_TIME_HOURLY` (3600), `BATCH_TIME_DAILY` (86400), and `BATCH_TIME_WEEKLY` (604800) constants to `UserSettings` alongside the existing `EMAIL_SEND_*` constants. Replaces all bare numeric literals (`3600`, `3600 * 24`, `3600 * 24 * 7`) in `MailQueueHandler` and `UserSettings` with the new constants.

## Test plan

- [x] `UserSettingsTest` — green
- [x] `MailQueueHandlerTest` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)