### PR TITLE
refactor: deduplicate getHTMLSubject() via HTMLSubjectFormatter

### DIFF
--- a/lib/DigestSender.php
+++ b/lib/DigestSender.php
@@ -220,27 +220,6 @@ class DigestSender {
 	 * @return string
 	 */
 	protected function getHTMLSubject(IEvent $event): string {
-		if ($event->getRichSubject() === '') {
-			return htmlspecialchars($event->getParsedSubject());
-		}
-
-		$placeholders = $replacements = [];
-		foreach ($event->getRichSubjectParameters() as $placeholder => $parameter) {
-			$placeholders[] = '{' . $placeholder . '}';
-
-			if ($parameter['type'] === 'file') {
-				$replacement = (string)$parameter['path'];
-			} else {
-				$replacement = (string)$parameter['name'];
-			}
-
-			if (isset($parameter['link'])) {
-				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
-			} else {
-				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
-			}
-		}
-
-		return str_replace($placeholders, $replacements, $event->getRichSubject());
+		return HTMLSubjectFormatter::format($event);
 	}
 }

--- a/lib/HTMLSubjectFormatter.php
+++ b/lib/HTMLSubjectFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Activity;
+
+use OCP\Activity\IEvent;
+
+class HTMLSubjectFormatter {
+	public static function format(IEvent $event): string {
+		if ($event->getRichSubject() === '') {
+			return htmlspecialchars($event->getParsedSubject());
+		}
+
+		$placeholders = $replacements = [];
+		foreach ($event->getRichSubjectParameters() as $placeholder => $parameter) {
+			$placeholders[] = '{' . $placeholder . '}';
+
+			$replacement = $parameter['type'] === 'file'
+				? (string)$parameter['path']
+				: (string)$parameter['name'];
+
+			if (isset($parameter['link'])) {
+				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
+			} else {
+				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
+			}
+		}
+
+		return str_replace($placeholders, $replacements, $event->getRichSubject());
+	}
+}

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -379,28 +379,7 @@ class MailQueueHandler {
 	}
 
 	protected function getHTMLSubject(IEvent $event): string {
-		if ($event->getRichSubject() === '') {
-			return htmlspecialchars($event->getParsedSubject());
-		}
-
-		$placeholders = $replacements = [];
-		foreach ($event->getRichSubjectParameters() as $placeholder => $parameter) {
-			$placeholders[] = '{' . $placeholder . '}';
-
-			if ($parameter['type'] === 'file') {
-				$replacement = (string)$parameter['path'];
-			} else {
-				$replacement = (string)$parameter['name'];
-			}
-
-			if (isset($parameter['link'])) {
-				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
-			} else {
-				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
-			}
-		}
-
-		return str_replace($placeholders, $replacements, $event->getRichSubject());
+		return HTMLSubjectFormatter::format($event);
 	}
 
 	/**

--- a/tests/HTMLSubjectFormatterTest.php
+++ b/tests/HTMLSubjectFormatterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Activity\Tests;
+
+use OCA\Activity\HTMLSubjectFormatter;
+use OCP\Activity\IEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class HTMLSubjectFormatterTest extends TestCase {
+	private function getEvent(string $richSubject, array $richParams, string $parsedSubject): IEvent&MockObject {
+		$event = $this->createMock(IEvent::class);
+		$event->method('getRichSubject')->willReturn($richSubject);
+		$event->method('getRichSubjectParameters')->willReturn($richParams);
+		$event->method('getParsedSubject')->willReturn($parsedSubject);
+		return $event;
+	}
+
+	public function testNoRichSubjectFallsToParsed(): void {
+		$event = $this->getEvent('', [], 'Plain <subject>');
+		$this->assertSame('Plain &lt;subject&gt;', HTMLSubjectFormatter::format($event));
+	}
+
+	public function testFileParameterUsesPath(): void {
+		$event = $this->getEvent(
+			'File {file} was changed',
+			['file' => ['type' => 'file', 'path' => '/my/file.txt', 'name' => 'file.txt']],
+			'',
+		);
+		$this->assertSame('File <strong>/my/file.txt</strong> was changed', HTMLSubjectFormatter::format($event));
+	}
+
+	public function testNonFileParameterUsesName(): void {
+		$event = $this->getEvent(
+			'{user} shared',
+			['user' => ['type' => 'user', 'name' => 'Alice & Bob']],
+			'',
+		);
+		$this->assertSame('<strong>Alice &amp; Bob</strong> shared', HTMLSubjectFormatter::format($event));
+	}
+
+	public function testParameterWithLinkRendersAnchor(): void {
+		$event = $this->getEvent(
+			'See {file}',
+			['file' => ['type' => 'file', 'path' => 'report.pdf', 'name' => 'report.pdf', 'link' => 'https://example.com/report.pdf']],
+			'',
+		);
+		$this->assertSame('See <a href="https://example.com/report.pdf">report.pdf</a>', HTMLSubjectFormatter::format($event));
+	}
+}


### PR DESCRIPTION
## Summary

`getHTMLSubject()` was copy-pasted identically in `MailQueueHandler` and `DigestSender` — any bug fix or change had to be applied twice.

Extracted to a static `HTMLSubjectFormatter::format(IEvent): string` class. Both callers now delegate to the single implementation; their `getHTMLSubject()` methods become one-liners.

Also adds four focused unit tests that were previously missing: no-rich-subject fallback (HTML-escaping), file-type parameter (uses `path`), non-file parameter (uses `name`), and parameter with a link (renders `<a>`).

## Test plan

- [x] 4 new `HTMLSubjectFormatterTest` cases — green
- [x] Full test suite (332 tests) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)