### PR TITLE
refactor(types): add native parameter and return types to UserSettings

### DIFF
--- a/lib/UserSettings.php
+++ b/lib/UserSettings.php
@@ -47,7 +47,7 @@ class UserSettings {
 	 * @param string $type One of the activity types, 'batchtime' or 'self'
 	 * @return bool|int
 	 */
-	public function getUserSetting($user, $method, $type) {
+	public function getUserSetting(string $user, string $method, string $type): bool|int {
 		if ($method === 'email' && $this->config->getAppValue('activity', 'enable_email', 'yes') === 'no') {
 			return false;
 		}
@@ -82,7 +82,7 @@ class UserSettings {
 	 * @param string $type
 	 * @return bool|int
 	 */
-	public function getAdminSetting($method, $type) {
+	public function getAdminSetting(string $method, string $type): bool|int {
 		$defaultSetting = $this->getDefaultSetting($method, $type);
 		if (is_bool($defaultSetting)) {
 			return (bool)$this->config->getAppValue(
@@ -106,7 +106,7 @@ class UserSettings {
 	 * @param string $type One of the activity types, 'batchtime', 'self' or 'selfemail'
 	 * @return bool|int
 	 */
-	protected function getDefaultSetting($method, $type) {
+	protected function getDefaultSetting(string $method, string $type): bool|int {
 		if ($method === 'setting') {
 			if ($type === 'batchtime') {
 				return 3600;
@@ -145,7 +145,7 @@ class UserSettings {
 	 * @param string $type One of the activity types, 'batchtime', 'self' or 'selfemail'
 	 * @return bool
 	 */
-	protected function canModifySetting($method, $type) {
+	protected function canModifySetting(string $method, string $type): bool {
 		if ($method === 'setting') {
 			return true;
 		}
@@ -168,7 +168,7 @@ class UserSettings {
 	/**
 	 * Get a list with all notification types
 	 */
-	public function getNotificationTypes() {
+	public function getNotificationTypes(): array {
 		$settings = $this->manager->getSettings();
 
 		$return = array_map(function (ActivitySettings $setting) {
@@ -194,7 +194,7 @@ class UserSettings {
 	 * @return array Returns a "username => b:true" Map for method = notification
 	 *               Returns a "username => i:batchtime" Map for method = email
 	 */
-	public function filterUsersBySetting($users, $method, $type) {
+	public function filterUsersBySetting(array $users, string $method, string $type): array {
 		if (empty($users)) {
 			return [];
 		}

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -77,17 +77,25 @@ class ConsumerTest extends TestCase {
 			->method('get')
 			->with('activity')
 			->willReturn($l10n);
+		$map = [
+			['affectedUser', 'notification', 'type', true],
+			['affectedUser2', 'notification', 'type', true],
+			['affectedUser', 'email', 'type', true],
+			['affectedUser2', 'email', 'type', true],
+			['affectedUser', 'setting', 'batchtime', 10],
+			['affectedUser2', 'setting', 'batchtime', 10],
+		];
 		$this->userSettings
 			->method('getUserSetting')
 			->with($this->stringContains('affectedUser'), $this->anything(), $this->anything())
-			->willReturnMap([
-				['affectedUser', 'notification', 'type', true],
-				['affectedUser2', 'notification', 'type', true],
-				['affectedUser', 'email', 'type', true],
-				['affectedUser2', 'email', 'type', true],
-				['affectedUser', 'setting', 'batchtime', 10],
-				['affectedUser2', 'setting', 'batchtime', 10],
-			]);
+			->willReturnCallback(function ($user, $method, $type) use ($map): bool|int {
+				foreach ($map as [$u, $m, $t, $v]) {
+					if ($u === $user && $m === $method && $t === $type) {
+						return $v;
+					}
+				}
+				return false;
+			});
 
 		$this->consumer = new Consumer(
 			$this->data,

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -720,8 +720,14 @@ class FilesHooksTest extends TestCase {
 
 		$this->settings->expects($this->exactly($settingCalls))
 			->method('filterUsersBySetting')
-			#->with($settingUsers, $this->anything(), Files_Sharing::TYPE_SHARED)
-			->willReturnMap($settingsReturn);
+			->willReturnCallback(function ($users, $method, $type) use ($settingsReturn): array {
+				foreach ($settingsReturn as [$u, $m, $t, $v]) {
+					if ($u === $users && $m === $method && $t === $type) {
+						return $v;
+					}
+				}
+				return [];
+			});
 
 		$filesHooks->expects($this->once())
 			->method('shareNotificationForSharer')


### PR DESCRIPTION
## Summary
- Add native PHP 8.x parameter and return types to all six `UserSettings` methods (`getUserSetting`, `getAdminSetting`, `getDefaultSetting`, `canModifySetting`, `getNotificationTypes`, `filterUsersBySetting`)
- Migrate two test mocks from `willReturnMap` to `willReturnCallback` so they return a typed default (`false` / `[]`) instead of `null` when no map entry matches

## Test plan
- [ ] `composer test:unit` passes (328 tests)

🤖 AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>