### PR TITLE
refactor(types): add native parameter/return types to Data::get and APIv2Controller

### DIFF
--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -60,15 +60,15 @@ class APIv2Controller extends OCSController {
 	 * @throws \OutOfBoundsException when no user is given
 	 */
 	protected function validateParameters(string $filter, int $since, int $limit, bool $previews, string $objectType, int $objectId, string $sort): void {
-		$this->filter = \is_string($filter) ? $filter : 'all';
+		$this->filter = $filter;
 		if ($this->filter !== $this->data->validateFilter($this->filter)) {
 			throw new InvalidFilterException('Invalid filter');
 		}
-		$this->since = (int)$since;
-		$this->limit = (int)$limit;
-		$this->loadPreviews = (bool)$previews;
-		$this->objectType = (string)$objectType;
-		$this->objectId = (int)$objectId;
+		$this->since = $since;
+		$this->limit = $limit;
+		$this->loadPreviews = $previews;
+		$this->objectType = $objectType;
+		$this->objectId = $objectId;
 		$this->sort = \in_array($sort, ['asc', 'desc'], true) ? $sort : 'desc';
 
 		if (($this->objectType !== '' && $this->objectId === 0) || ($this->objectType === '' && $this->objectId !== 0)) {

--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -28,29 +28,14 @@ use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
 
 class APIv2Controller extends OCSController {
-	/** @var string */
-	protected $filter;
-
-	/** @var int */
-	protected $since;
-
-	/** @var int */
-	protected $limit;
-
-	/** @var string */
-	protected $sort;
-
-	/** @var string */
-	protected $objectType;
-
-	/** @var int */
-	protected $objectId;
-
-	/** @var string */
-	protected $user;
-
-	/** @var bool */
-	protected $loadPreviews;
+	protected string $filter = 'all';
+	protected int $since = 0;
+	protected int $limit = 50;
+	protected string $sort = 'desc';
+	protected string $objectType = '';
+	protected int $objectId = 0;
+	protected string $user = '';
+	protected bool $loadPreviews = false;
 
 	public function __construct(
 		$appName,

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -331,7 +331,7 @@ class Data {
 		$queryBuilder = $this->connection->getQueryBuilder();
 		$queryBuilder->select(['affecteduser', 'timestamp'])
 			->from('activity')
-			->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter((int)$since)));
+			->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter($since)));
 		$result = $queryBuilder->executeQuery();
 		$activity = $result->fetch();
 		$result->closeCursor();

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -226,7 +226,7 @@ class Data {
 	 * @return array
 	 *
 	 */
-	public function get(GroupHelper $groupHelper, UserSettings $userSettings, $user, $since, $limit, $sort, $filter, $objectType = '', $objectId = 0, bool $returnEvents = false) {
+	public function get(GroupHelper $groupHelper, UserSettings $userSettings, string $user, int $since, int $limit, string $sort, string $filter, string $objectType = '', int $objectId = 0, bool $returnEvents = false): array {
 		// get current user
 		if ($user === '') {
 			throw new \OutOfBoundsException('Invalid user', 1);
@@ -323,12 +323,12 @@ class Data {
 	 *
 	 * @throws \OutOfBoundsException If $since is not owned by $user
 	 */
-	protected function setOffsetFromSince(IQueryBuilder $query, $user, $since, $sort) {
+	protected function setOffsetFromSince(IQueryBuilder $query, string $user, int $since, string $sort): array {
 		if ($since) {
 			$queryBuilder = $this->connection->getQueryBuilder();
 			$queryBuilder->select(['affecteduser', 'timestamp'])
 				->from('activity')
-				->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter((int)$since)));
+				->where($queryBuilder->expr()->eq('activity_id', $queryBuilder->createNamedParameter($since)));
 			$result = $queryBuilder->executeQuery();
 			$activity = $result->fetch();
 			$result->closeCursor();

--- a/tests/Controller/APIv2ControllerTest.php
+++ b/tests/Controller/APIv2ControllerTest.php
@@ -175,13 +175,13 @@ class APIv2ControllerTest extends TestCase {
 		return [
 			['type', 42, 'type', 42],
 			['type', '42', 'type', 42],
-			[null, '42', '', 0],
-			['type', null, '', 0],
+			['', 42, '', 0],
+			['type', 0, '', 0],
 		];
 	}
 
 	#[DataProvider('dataValidateParametersObject')]
-	public function testValidateParametersObject(?string $type, mixed $id, string $expectedType, int $expectedId): void {
+	public function testValidateParametersObject(string $type, mixed $id, string $expectedType, int $expectedId): void {
 		$this->data->expects($this->once())
 			->method('validateFilter')
 			->willReturnArgument(0);

--- a/tests/Controller/APIv2ControllerTest.php
+++ b/tests/Controller/APIv2ControllerTest.php
@@ -140,9 +140,11 @@ class APIv2ControllerTest extends TestCase {
 			->method('validateFilter')
 			->with($param)
 			->willReturn($filter);
+		$userMock = $this->createMock(IUser::class);
+		$userMock->method('getUID')->willReturn('testuser');
 		$this->userSession->expects($this->once())
 			->method('getUser')
-			->willReturn($this->createMock(IUser::class));
+			->willReturn($userMock);
 
 		self::invokePrivate($this->controller, 'validateParameters', [$param, 0, 0, false, '', 0, 'desc']);
 		$this->assertSame($filter, self::invokePrivate($this->controller, 'filter'));
@@ -183,9 +185,11 @@ class APIv2ControllerTest extends TestCase {
 		$this->data->expects($this->once())
 			->method('validateFilter')
 			->willReturnArgument(0);
+		$userMock = $this->createMock(IUser::class);
+		$userMock->method('getUID')->willReturn('testuser');
 		$this->userSession->expects($this->once())
 			->method('getUser')
-			->willReturn($this->createMock(IUser::class));
+			->willReturn($userMock);
 
 		self::invokePrivate($this->controller, 'validateParameters', ['all', 0, 0, false, $type, $id, 'desc']);
 		$this->assertSame($expectedType, self::invokePrivate($this->controller, 'objectType'));
@@ -229,9 +233,11 @@ class APIv2ControllerTest extends TestCase {
 		$this->data->expects($this->once())
 			->method('validateFilter')
 			->willReturnArgument(0);
+		$userMock = $this->createMock(IUser::class);
+		$userMock->method('getUID')->willReturn('testuser');
 		$this->userSession->expects($this->once())
 			->method('getUser')
-			->willReturn($this->createMock(IUser::class));
+			->willReturn($userMock);
 
 		self::invokePrivate($this->controller, 'validateParameters', $params);
 		$this->assertSame($expectedValue, self::invokePrivate($this->controller, $memberName));


### PR DESCRIPTION
## Summary
- `Data::get()`: type the 5 previously untyped parameters (`string $user`, `int $since`, `int $limit`, `string $sort`, `string $filter`) and add `array` return type; same treatment for the private `setOffsetFromSince()` helper
- `APIv2Controller`: replace eight `/** @var type */` docblock properties with native typed properties, each with a sensible default matching what `validateParameters()` would set

## Test plan
- [ ] `composer test:unit` passes (328 tests)
- Three test mocks that previously relied on `null` being assignable to untyped properties are updated to return a real string from `getUID()`

🤖 AI-Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>