### PR TITLE
fix: Limit active-icon inversion to legacy nav design

### DIFF
--- a/src/views/ActivityAppNavigation.vue
+++ b/src/views/ActivityAppNavigation.vue
@@ -135,11 +135,11 @@ async function copyRSSLink() {
 	}
 
 	.app-navigation-entry {
-		&.active .navigation-icon {
+		&.app-navigation-entry--legacy.active .navigation-icon {
 			filter: var(--primary-invert-if-dark);
 		}
 
-		&:not(.active) .navigation-icon {
+		&:not(.app-navigation-entry--legacy.active) .navigation-icon {
 			filter: var(--background-invert-if-dark);
 		}
 	}


### PR DESCRIPTION
## Summary

On Nextcloud 34+ the active app-navigation entry background is a soft tinted color rather than the previous solid primary. The existing icon-filter inverts to white assuming the old dark primary background, so on the new design active icons render white on a light tint.

This restricts the inverted filter to the legacy nav design (NC < 34), where the active background is still the solid primary and the inversion is correct. On the new design, active icons keep the regular background-aware filter.

Same fix shape as nextcloud/server#60243 for the equivalent regression in Settings.

## Test plan

- [ ] On Nextcloud 34+, open Activity, click any sidebar entry: active icon renders with normal contrast (not white-on-tint).
- [ ] On Nextcloud < 34, active icon still renders white on the solid primary active background.