### PR TITLE
fix(NotificationGenerator): catch InvalidArgumentException from notification setters in prepare()

### DIFF
--- a/lib/NotificationGenerator.php
+++ b/lib/NotificationGenerator.php
@@ -118,7 +118,12 @@ class NotificationGenerator implements INotifier {
 		$event = $this->populateEvent($event, $languageCode);
 		$this->activityManager->setCurrentUserId(null);
 
-		return $this->getDisplayNotificationForEvent($event, $event->getObjectId());
+		try {
+			return $this->getDisplayNotificationForEvent($event, $event->getObjectId());
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->error('Failed to format activity notification', ['exception' => $e]);
+			throw new AlreadyProcessedException();
+		}
 	}
 
 	private function getDisplayNotificationForEvent(IEvent $event, int $activityId): INotification {


### PR DESCRIPTION
## Summary

- `INotification` setters (`setRichSubject()`, `setParsedSubject()`) throw `\InvalidArgumentException` for empty/invalid values
- These previously escaped `prepare()`, triggering the NC39 deprecation: _"threw \InvalidArgumentException which is deprecated"_
- Fix catches the exception, logs it as an error, and throws `AlreadyProcessedException` to discard the unrenderable notification

## Test plan
- [x] Run unit tests: `composer test:unit`
- [x] Verify no `\InvalidArgumentException` escapes `prepare()` in the activity notifier logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)