### PR TITLE
fix: fix null array key error in fixPathsForShareExceptions

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -1047,7 +1047,9 @@ class FilesHooks {
 		$query = $queryBuilder->executeQuery();
 
 		while ($row = $query->fetch()) {
-			$affectedUsers[$row['share_with']] = $row['file_target'];
+			if ($row['share_with'] !== null) {
+				$affectedUsers[$row['share_with']] = $row['file_target'];
+			}
 		}
 
 		return $affectedUsers;


### PR DESCRIPTION
Starting with php 8.5 this is a hard error.