### PR TITLE
feat: make amount of items sent on email configurable via occ

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -36,8 +36,8 @@ use Psr\Log\LoggerInterface;
 class MailQueueHandler {
 	public const CLI_EMAIL_BATCH_SIZE = 500;
 	public const WEB_EMAIL_BATCH_SIZE = 25;
-	/** Number of entries we want to list in the email */
-	public const ENTRY_LIMIT = 200;
+	public const MAIL_MAX_ITEMS_DEFAULT = 200;
+	public const MAIL_MAX_ITEMS_CAP = 1000;
 
 	protected array $languages;
 	protected string $senderAddress;
@@ -191,7 +191,7 @@ class MailQueueHandler {
 	 *
 	 * @return array [data of the first max. 200 entries, total number of entries]
 	 */
-	protected function getItemsForUser(string $affectedUser, int $maxTime, int $maxNumItems = self::ENTRY_LIMIT): array {
+	protected function getItemsForUser(string $affectedUser, int $maxTime, int $maxNumItems = self::MAIL_MAX_ITEMS_DEFAULT): array {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
 			->from('activity_mq')
@@ -282,7 +282,7 @@ class MailQueueHandler {
 			return true;
 		}
 
-		[$mailData, $skippedCount] = $this->getItemsForUser($userName, $maxTime);
+		[$mailData, $skippedCount] = $this->getItemsForUser($userName, $maxTime, $this->getMailMaxItems());
 
 		$l = $this->getLanguage($lang);
 		$this->activityManager->setCurrentUserId($userName);
@@ -415,5 +415,16 @@ class MailQueueHandler {
 			->where($query->expr()->lte('amq_timestamp', $query->createNamedParameter($maxTime, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->in('amq_affecteduser', $query->createNamedParameter($affectedUsers, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR));
 		$query->executeStatement();
+	}
+
+	private function getMailMaxItems(): int {
+		$maxItems = $this->appConfig->getValueInt('activity', 'mail_max_items', self::MAIL_MAX_ITEMS_DEFAULT);
+		if ($maxItems < 1) {
+			return 1;
+		}
+		if ($maxItems > self::MAIL_MAX_ITEMS_CAP) {
+			return self::MAIL_MAX_ITEMS_CAP;
+		}
+		return $maxItems;
 	}
 }

--- a/tests/MailQueueHandlerTest.php
+++ b/tests/MailQueueHandlerTest.php
@@ -402,6 +402,26 @@ class MailQueueHandlerTest extends TestCase {
 		}
 	}
 
+	public function testGetMailMaxItemsReturnsCapWhenValueExceedsCap(): void {
+		$this->appConfig->method('getValueInt')
+			->with('activity', 'mail_max_items', $this->mailQueueHandler::MAIL_MAX_ITEMS_DEFAULT)
+			->willReturn(9999);
+
+		$result = self::invokePrivate($this->mailQueueHandler, 'getMailMaxItems', []);
+
+		$this->assertSame(MailQueueHandler::MAIL_MAX_ITEMS_CAP, $result);
+	}
+
+	public function testGetMailMaxItemsReturnsOneWhenValueIsBelowOne(): void {
+		$this->appConfig->method('getValueInt')
+			->with('activity', 'mail_max_items', $this->mailQueueHandler::MAIL_MAX_ITEMS_DEFAULT)
+			->willReturn(0);
+
+		$result = self::invokePrivate($this->mailQueueHandler, 'getMailMaxItems', []);
+
+		$this->assertSame(1, $result);
+	}
+
 	/**
 	 * @param array $users
 	 * @param int $maxTime


### PR DESCRIPTION
* Resolves: #

## Summary

### Context
- activity emails are sent to users via the `OCA\Activity\BackgroundJob\EmailNotification` background job
- the background job calls `MailQueueHandler::sendEmails()`
- `MailQueueHandler::ENTRY_LIMIT` defines how many activities are fully shown in the email body, anything beyond that is truncated, as shown below:

<img width="652" height="353" alt="image" src="https://github.com/user-attachments/assets/ed09002d-f426-4701-83ec-1cddeb3d8ab0" />

### Changes introduced by this PR
- adds an admin-configurable setting to control the max number of activities fully shown in notification emails:
```bash
occ config:app:set activity mail_max_items --value=500
```
- falls back to 200 (original value) when no configuration is set
- adds `MailQueueHandler::MAIL_MAX_ITEMS_CAP` as a safeguard against excessively large values

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
