### PR TITLE
Fix: Remove user memoization

### DIFF
--- a/lib/CurrentUser.php
+++ b/lib/CurrentUser.php
@@ -17,13 +17,6 @@ use OCP\Share\IShare;
 
 class CurrentUser {
 
-	/** @var string|null */
-	protected $identifier = null;
-	/** @var string|false|null */
-	protected $cloudId = false;
-	/** @var string|false|null */
-	protected $sessionUser = false;
-
 	public function __construct(
 		protected IUserSession $userSession,
 		protected IRequest $request,
@@ -41,31 +34,23 @@ class CurrentUser {
 	 * @return string
 	 */
 	public function getUserIdentifier() {
-		if ($this->identifier !== null) {
-			return $this->identifier;
-		}
-
 		$uid = $this->getUID();
 		if ($uid !== null) {
-			$this->identifier = $uid;
-			return $this->identifier;
+			return $uid;
 		}
 
 		$cloudId = $this->getCloudIDFromToken();
 		if ($cloudId !== null) {
-			$this->identifier = $cloudId;
-			return $this->identifier;
+			return $cloudId;
 		}
 
 		$nickname = htmlspecialchars($this->request->getHeader('X-NC-Nickname'));
 		if ($nickname !== '') {
-			$this->identifier = $nickname . ' (' . $this->l10nFactory->get('comments')->t('remote user') . ')';
-			return $this->identifier;
+			return $nickname . ' (' . $this->l10nFactory->get('comments')->t('remote user') . ')';
 		}
 
 		// Nothing worked, fallback to empty string
-		$this->identifier = '';
-		return $this->identifier;
+		return '';
 	}
 
 	/**
@@ -73,16 +58,11 @@ class CurrentUser {
 	 * @return string|null
 	 */
 	public function getUID() {
-		if ($this->sessionUser === false) {
-			$user = $this->userSession->getUser();
-			if ($user instanceof IUser) {
-				$this->sessionUser = $user->getUID();
-			} else {
-				$this->sessionUser = null;
-			}
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser) {
+			return (string)$user->getUID();
 		}
-
-		return $this->sessionUser;
+		return null;
 	}
 
 	/**
@@ -90,16 +70,12 @@ class CurrentUser {
 	 * @return string|null
 	 */
 	public function getCloudId() {
-		if ($this->cloudId === false) {
-			$user = $this->userSession->getUser();
-			if ($user instanceof IUser) {
-				$this->cloudId = (string)$user->getCloudId();
-			} else {
-				$this->cloudId = $this->getCloudIDFromToken();
-			}
+		$user = $this->userSession->getUser();
+		if ($user instanceof IUser) {
+			return (string)$user->getCloudId();
+		} else {
+			return $this->getCloudIDFromToken();
 		}
-
-		return $this->cloudId;
 	}
 
 	/**

--- a/tests/CurrentUserTest.php
+++ b/tests/CurrentUserTest.php
@@ -85,7 +85,6 @@ class CurrentUserTest extends TestCase {
 			[null, null, null, ''],
 			[null, 'uid', -1, 'uid'],
 			[null, null, 'token', 'token'],
-			['cached', -1, -1, 'cached'],
 		];
 	}
 
@@ -95,8 +94,6 @@ class CurrentUserTest extends TestCase {
 			'getUID',
 			'getCloudIDFromToken',
 		]);
-
-		self::invokePrivate($instance, 'identifier', [$cachedIdentifier]);
 
 		$instance->expects($uidResult !== -1 ? $this->once() : $this->never())
 			->method('getUID')


### PR DESCRIPTION
User memoization in the Activity app causes incorrect activity notifications in edge cases, particularly when activities are generated about files changed by other users. This was observed in the Forms app.

**Reproducer**:
1. Alice creates a form with submissions linked to file1.xlsx
2. Bob creates a form with submissions linked to file2.xlsx
3. Both forms are submitted quickly
4. Wait for [`SyncSubmissionsWithLinkedFileJob`](https://github.com/nextcloud/forms/blob/main/lib/BackgroundJob/SyncSubmissionsWithLinkedFileJob.php) to execute

**Root cause**:
The memoized user state persists across console commands and background jobs, even when the user context changes via:
```php
$user = $this->userManager->get($ownerId);
$this->userSession->setUser($user);
```

**Solution**:
Remove user memoization at the Activity level since it's not needed and causes state leakage between different user contexts.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
