### PR TITLE
fix(renovate): remove expandCodeOwnersGroups (paid-tier feature)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,6 @@
     ":gitSignOff"
   ],
   "assigneesFromCodeOwners": true,
-  "expandCodeOwnersGroups": true,
   "timezone": "Europe/Berlin",
   "schedule": ["before 5am on saturday"],
   "labels": ["dependencies", "3. to review"],


### PR DESCRIPTION
## Summary

- Removes `expandCodeOwnersGroups` from `renovate.json` — this is a Mend Renovate paid-tier feature and logs a warning on the free GitHub App

The `config.platform` warning from composer.json is cosmetic and not actionable (Renovate can't interpret the fake PHP platform version but still functions correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)