### PR TITLE
fix: do not fail moves when the old location cannot be resolved

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -43,7 +43,7 @@ class FilesHooks {
 
 	/** @var string|bool */
 	protected $moveCase = false;
-	/** @var array */
+	/** @var array|null */
 	protected $oldAccessList;
 	/** @var string */
 	protected $oldParentPath;
@@ -275,22 +275,30 @@ class FilesHooks {
 			$this->moveCase = 'moveCross';
 		}
 
-		[$this->oldParentPath, $this->oldParentOwner, $this->oldParentId] = $this->getSourcePathAndOwner($oldDir);
-		if ($this->oldParentId === 0) {
-			// Could not find the file for the owner ...
+		try {
+			[$this->oldParentPath, $this->oldParentOwner, $this->oldParentId] = $this->getSourcePathAndOwner($oldDir);
+			if ($this->oldParentId === 0) {
+				// Could not find the file for the owner ...
+				$this->moveCase = false;
+				return;
+			}
+
+			$oldAccessList = $this->getUserPathsFromPath($this->oldParentPath, $this->oldParentOwner);
+
+			// file can be shared using GroupFolders, including ACL check
+			if ($this->config->getSystemValueBool('activity_use_cached_mountpoints', false)) {
+				[, , $oldFileId] = $this->getSourcePathAndOwner($oldPath);
+				$oldAccessList['users'] = array_merge($oldAccessList['users'], $this->getAffectedUsersFromCachedMounts($oldFileId));
+			}
+
+			$this->oldAccessList = $oldAccessList;
+		} catch (NotFoundException $e) {
+			// The old location cannot be resolved (e.g. inconsistent mount or file
+			// cache state), so fileMovePost() would have no valid data to build
+			// activities from. Skip it instead of failing the move half-way.
+			$this->logger->warning('Could not resolve the old location of "' . $oldPath . '", no move activities will be created', ['exception' => $e]);
 			$this->moveCase = false;
-			return;
 		}
-
-		$oldAccessList = $this->getUserPathsFromPath($this->oldParentPath, $this->oldParentOwner);
-
-		// file can be shared using GroupFolders, including ACL check
-		if ($this->config->getSystemValueBool('activity_use_cached_mountpoints', false)) {
-			[, , $oldFileId] = $this->getSourcePathAndOwner($oldPath);
-			$oldAccessList['users'] = array_merge($oldAccessList['users'], $this->getAffectedUsersFromCachedMounts($oldFileId));
-		}
-
-		$this->oldAccessList = $oldAccessList;
 	}
 
 	/**
@@ -390,6 +398,12 @@ class FilesHooks {
 	 * @param string $newPath
 	 */
 	protected function fileMoving($oldPath, $newPath) {
+		if (!is_array($this->oldAccessList)) {
+			// fileMove() could not collect the old access list, so there is no
+			// base to compute the activities from
+			return;
+		}
+
 		$dirName = dirname($newPath);
 		$fileName = basename($newPath);
 		$oldFileName = basename($oldPath);

--- a/tests/FilesHooksTest.php
+++ b/tests/FilesHooksTest.php
@@ -488,6 +488,65 @@ class FilesHooksTest extends TestCase {
 		$this->assertEquals($addCalls, array_slice($receivedActivities, 0, count($addCalls)));
 	}
 
+	public function testFileMoveCollectsOldAccessList(): void {
+		$filesHooks = $this->getFilesHooks([
+			'getSourcePathAndOwner',
+			'getUserPathsFromPath',
+		]);
+
+		$filesHooks->expects($this->once())
+			->method('getSourcePathAndOwner')
+			->with('/folder')
+			->willReturn(['/folder', 'owner', 23]);
+		$filesHooks->expects($this->once())
+			->method('getUserPathsFromPath')
+			->with('/folder', 'owner')
+			->willReturn(['users' => ['user' => '/folder'], 'remotes' => []]);
+
+		$filesHooks->fileMove('/folder/file.txt', '/target/file.txt');
+
+		$this->assertSame('moveCross', self::invokePrivate($filesHooks, 'moveCase'));
+		$this->assertSame(['users' => ['user' => '/folder'], 'remotes' => []], self::invokePrivate($filesHooks, 'oldAccessList'));
+	}
+
+	public function testFileMoveOldPathNotResolvable(): void {
+		$filesHooks = $this->getFilesHooks([
+			'getSourcePathAndOwner',
+			'getUserPathsFromPath',
+			'fileRenaming',
+			'fileMoving',
+		]);
+
+		$filesHooks->expects($this->once())
+			->method('getSourcePathAndOwner')
+			->with('/folder')
+			->willThrowException(new NotFoundException('File with id "1337" has not been found.'));
+		$filesHooks->expects($this->never())
+			->method('getUserPathsFromPath');
+		$filesHooks->expects($this->never())
+			->method('fileRenaming');
+		$filesHooks->expects($this->never())
+			->method('fileMoving');
+
+		$filesHooks->fileMove('/folder/file.txt', '/target/file.txt');
+
+		$this->assertFalse(self::invokePrivate($filesHooks, 'moveCase'));
+
+		// the post hook must be a no-op instead of failing on the missing state
+		$filesHooks->fileMovePost('/folder/file.txt', '/target/file.txt');
+	}
+
+	public function testFileMovingWithoutOldAccessList(): void {
+		$filesHooks = $this->getFilesHooks([
+			'getSourcePathAndOwner',
+		]);
+
+		$filesHooks->expects($this->never())
+			->method('getSourcePathAndOwner');
+
+		self::invokePrivate($filesHooks, 'fileMoving', ['/folder/file.txt', '/target/file.txt']);
+	}
+
 	private function getNodeMock(int $fileId = 1337, string $path = 'path', bool $isFile = true): Node&MockObject {
 		if ($isFile) {
 			$node = $this->createMock(File::class);


### PR DESCRIPTION
Related: https://github.com/nextcloud/groupfolders/issues/4548
This has been found by analyzing the stack traces in that issue.

When the pre-rename hook cannot resolve the old location of a move by file id (NotFoundException from `View::getPath()`, e.g. on instances with inconsistent mount or file cache state), `fileMove()` aborted after setting `$this->moveCase` but before collecting `$this->oldAccessList`.

The post-rename hook then crashed with "`TypeError: array_keys(): Argument #1 ($array) must be of type array, null given`" in `fileMoving()`. Since `OC_Hook::emit()` only catches Exceptions, the TypeError failed the whole WebDAV MOVE request after the files had already been moved, leaving clients out of sync with the server.

Collect the state in `fileMove()` under a NotFoundException guard that disables the post hook handling instead, and bail out of `fileMoving()` if the old access list was never collected.

Actually, this results in things like files being moved correctly on disk, but not on `oc_filecache`, and only a manual scan will fix it.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
