### PR TITLE
[stable33] fix(deps): pin nextcloud/ocp to dev-stable33 in psalm vendor-bin

### DIFF
--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"nextcloud/ocp": "dev-master",
+		"nextcloud/ocp": "dev-stable33",
 		"vimeo/psalm": "^6.13.1"
 	},
 	"config": {

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cde3b0c29180ef545e96e92711568116",
+    "content-hash": "fe6935e322bc4085cfcc3971086cf062",
     "packages": [],
     "packages-dev": [
         {
@@ -1628,30 +1628,29 @@
         },
         {
             "name": "nextcloud/ocp",
-            "version": "dev-master",
+            "version": "dev-stable33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c8103ef4440e6759b4c9ed9edbefec028d1b9196"
+                "reference": "084aa73a1b73a2eacb7c4d75897f8aa52e8ecb71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c8103ef4440e6759b4c9ed9edbefec028d1b9196",
-                "reference": "c8103ef4440e6759b4c9ed9edbefec028d1b9196",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/084aa73a1b73a2eacb7c4d75897f8aa52e8ecb71",
+                "reference": "084aa73a1b73a2eacb7c4d75897f8aa52e8ecb71",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5",
+                "php": "~8.2 || ~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
                 "psr/log": "^3.0.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "34.0.0-dev"
+                    "dev-stable33": "33.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1671,9 +1670,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-02-05T13:36:04+00:00"
+            "time": "2026-06-27T02:06:20+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
## Summary

`vendor-bin/psalm/composer.json` was still requiring `nextcloud/ocp:dev-master`, a leftover from before stable33 was cut. `nextcloud/ocp`'s master branch now requires PHP `~8.3 || ~8.4 || ~8.5`, while this file pins `platform.php` to `8.2.27` — so the weekly ["Update nextcloud/ocp"](https://github.com/nextcloud/activity/actions/workflows/update-nextcloud-ocp.yml) automation has been failing every run (see #2785).

Points it at `dev-stable33` instead, matching the pattern already used on stable32.

AI-Assisted-By: ClaudeCode:claude-sonnet-5

## Checklist

- [x] Sign-off message is added
- [x] Backports requested where applicable (n/a — this is itself a stable-branch-specific fix)
