### PR TITLE
[stable34] fix(deps): pin nextcloud/ocp to dev-stable34 in psalm vendor-bin

### DIFF
--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
-		"nextcloud/ocp": "dev-master",
+		"nextcloud/ocp": "dev-stable34",
 		"vimeo/psalm": "^6.16.1"
 	},
 	"config": {

--- a/vendor-bin/psalm/composer.lock
+++ b/vendor-bin/psalm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceadaa233c0741cd07f48ddfa0e398d5",
+    "content-hash": "f84bb0ba0ea7dae1745b8e02426d8483",
     "packages": [],
     "packages-dev": [
         {
@@ -1628,30 +1628,30 @@
         },
         {
             "name": "nextcloud/ocp",
-            "version": "dev-master",
+            "version": "dev-stable34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c8103ef4440e6759b4c9ed9edbefec028d1b9196"
+                "reference": "2dcb60c95021914893db2776207bfacc4226f7d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c8103ef4440e6759b4c9ed9edbefec028d1b9196",
-                "reference": "c8103ef4440e6759b4c9ed9edbefec028d1b9196",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/2dcb60c95021914893db2776207bfacc4226f7d1",
+                "reference": "2dcb60c95021914893db2776207bfacc4226f7d1",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5",
+                "php": "~8.2 || ~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
+                "psr/http-client": "^1.0.3",
                 "psr/log": "^3.0.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "34.0.0-dev"
+                    "dev-stable34": "34.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1671,9 +1671,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-02-05T13:36:04+00:00"
+            "time": "2026-07-15T01:17:58+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2106,6 +2106,58 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",


### PR DESCRIPTION
## Summary

`vendor-bin/psalm/composer.json` was still requiring `nextcloud/ocp:dev-master`, a leftover from before stable34 was cut. `nextcloud/ocp`'s master branch now requires PHP `~8.3 || ~8.4 || ~8.5`, while this file pins `platform.php` to `8.2.27` — so the weekly ["Update nextcloud/ocp"](https://github.com/nextcloud/activity/actions/workflows/update-nextcloud-ocp.yml) automation has been failing every run (see #2788).

Points it at `dev-stable34` instead, matching the pattern already used on stable32. Also picked up a few already-pending minor bumps in the psalm vendor-bin lock (psalm itself was locked to 6.14.3 while composer.json already asked for ^6.16.1) as a side effect of regenerating the lock file.

AI-Assisted-By: ClaudeCode:claude-sonnet-5

## Checklist

- [x] Sign-off message is added
- [x] Backports requested where applicable (n/a — this is itself a stable-branch-specific fix)
