### PR TITLE
fix: stop using deprecated IAppContainer::getServer()

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -155,16 +155,14 @@ class Application extends App implements IBootstrap {
 	 */
 	private function registerActivityConsumer(): void {
 		$c = $this->getContainer();
-		$server = $c->getServer();
 
-		$server->get(IManager::class)->registerConsumer(function () use ($c) {
+		$c->get(IManager::class)->registerConsumer(function () use ($c) {
 			return $c->get(Consumer::class);
 		});
 	}
 
 	public function registerNotifier(): void {
-		$server = $this->getContainer()->getServer();
-		$server->get(INotificationManager::class)->registerNotifierService(NotificationGenerator::class);
+		$this->getContainer()->get(INotificationManager::class)->registerNotifierService(NotificationGenerator::class);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- `App::getContainer()` is now typed as returning `Psr\Container\ContainerInterface` instead of the deprecated `IAppContainer` (nextcloud/server@1d55835d39, "refactor: Remove most usages of IAppContainer and IServerContainer"), so psalm flags `->getServer()` as undefined on the narrower type in current Renovate PRs bumping `nextcloud/ocp`.
- `getServer()` has been deprecated since Nextcloud 20 anyway, and the app container's `get()` already resolves core/server services directly (same pattern used throughout `DIContainer` itself), so it was redundant.
- Replaced both call sites in `registerActivityConsumer()` and `registerNotifier()` with direct `$c->get(...)` / `$this->getContainer()->get(...)` calls.

## Test plan
- [x] Ran `composer update nextcloud/ocp --with-dependencies` to pull the same OCP commit CI uses, then `composer run psalm` — no errors (previously 3 `UndefinedInterfaceMethod`/`MissingPureAnnotation` errors on `getServer()`)
- [ ] CI green on this PR
- [x] AI assisted