### PR TITLE
fix(mail): escape rich-object link when building HTML email subject

### DIFF
--- a/lib/DigestSender.php
+++ b/lib/DigestSender.php
@@ -235,7 +235,7 @@ class DigestSender {
 			}
 
 			if (isset($parameter['link'])) {
-				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
+				$replacements[] = '<a href="' . htmlspecialchars((string)$parameter['link'], ENT_QUOTES) . '">' . htmlspecialchars($replacement) . '</a>';
 			} else {
 				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
 			}

--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -393,7 +393,7 @@ class MailQueueHandler {
 			}
 
 			if (isset($parameter['link'])) {
-				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
+				$replacements[] = '<a href="' . htmlspecialchars((string)$parameter['link'], ENT_QUOTES) . '">' . htmlspecialchars($replacement) . '</a>';
 			} else {
 				$replacements[] = '<strong>' . htmlspecialchars($replacement) . '</strong>';
 			}


### PR DESCRIPTION
The link parameter of rich subject parameters was interpolated into the href attribute of notification and digest emails without escaping, allowing attribute/markup injection into outgoing mail by any activity provider or federated source whose link contains a double quote.

Escape the link with htmlspecialchars(ENT_QUOTES), matching the escaping already applied to the link text.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
