### PR TITLE
fix(files): do not publish incompletely built activity events

### DIFF
--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -1213,6 +1213,8 @@ class FilesHooks {
 					'exception' => $e,
 				],
 			);
+			// Do not publish the incompletely built event
+			return;
 		}
 
 		// Add activity to stream


### PR DESCRIPTION
When building the activity event threw \InvalidArgumentException, the error was logged but execution fell through, so the partially initialized event was still stored in the stream, queued for email and pushed as a notification. Return after logging instead.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
