### PR TITLE
fix(mail): stop CLI email loops spinning on users that fail to load

### DIFF
--- a/lib/MailQueueHandler.php
+++ b/lib/MailQueueHandler.php
@@ -136,7 +136,10 @@ class MailQueueHandler {
 		// Delete all entries we dealt with
 		$this->deleteSentItems($deleteItemsForUsers, $sendTime);
 
-		return count($affectedUsers);
+		// Only count the users that were actually dealt with, so a batch of
+		// users whose lookup failed does not keep the CLI loops of the
+		// callers spinning on the same batch forever.
+		return count($deleteItemsForUsers);
 	}
 
 	/**


### PR DESCRIPTION
When looking up a user threw, sendEmails() skipped the user without removing their queue entries. Since getAffectedUsers() always returns the users with the oldest pending items first, and both EmailNotification (cron) and the send-emails command loop while a full batch was reported, a full batch of users with a broken user backend made those loops spin on the same batch forever, retrying and logging endlessly within one run.

Report the number of users actually dealt with instead of the number of affected users, so a batch containing failed lookups ends the loop and the skipped users are retried on the next run. This also matches the documented return value. Entries of users that fail to load are still kept for retry: a lookup for a deleted user returns null (handled via the empty-email path), a throw indicates a temporarily broken backend and pending emails should not be discarded because of it.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
