### PR TITLE
chore: run composer cs:fix to satisfy php-cs (stable32)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\AppInfo;
 
 use OC\DB\ConnectionAdapter;
@@ -83,12 +84,12 @@ class Application extends App implements IBootstrap {
 			$systemConfig = $c->get(SystemConfig::class);
 			$configPrefix = 'activity_';
 
-			if ($systemConfig->getValue($configPrefix . 'dbuser', null) === null &&
-				$systemConfig->getValue($configPrefix . 'dbpassword', null) === null &&
-				$systemConfig->getValue($configPrefix . 'dbname', null) === null &&
-				$systemConfig->getValue($configPrefix . 'dbhost', null) === null &&
-				$systemConfig->getValue($configPrefix . 'dbport', null) === null &&
-				$systemConfig->getValue($configPrefix . 'dbdriveroptions', null) === null) {
+			if ($systemConfig->getValue($configPrefix . 'dbuser', null) === null
+				&& $systemConfig->getValue($configPrefix . 'dbpassword', null) === null
+				&& $systemConfig->getValue($configPrefix . 'dbname', null) === null
+				&& $systemConfig->getValue($configPrefix . 'dbhost', null) === null
+				&& $systemConfig->getValue($configPrefix . 'dbport', null) === null
+				&& $systemConfig->getValue($configPrefix . 'dbdriveroptions', null) === null) {
 				return $c->get(IDBConnection::class);
 			}
 

--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\BackgroundJob;
 
 use OCA\Activity\MailQueueHandler;

--- a/lib/BackgroundJob/ExpireActivities.php
+++ b/lib/BackgroundJob/ExpireActivities.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\BackgroundJob;
 
 use OCA\Activity\Data;

--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity;
 
 use OCP\Activity\ActivitySettings;

--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\Data;

--- a/lib/Controller/ActivitiesController.php
+++ b/lib/Controller/ActivitiesController.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\Data;

--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\Data;

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\CurrentUser;

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity;
 
 use Doctrine\DBAL\Platforms\MySQLPlatform;
@@ -272,8 +273,8 @@ class Data {
 		}
 
 		if (
-			$filter === 'files_favorites' ||
-			(in_array($filter, ['all', 'by', 'self']) && $userSettings->getUserSetting($user, 'stream', 'files_favorites'))
+			$filter === 'files_favorites'
+			|| (in_array($filter, ['all', 'by', 'self']) && $userSettings->getUserSetting($user, 'stream', 'files_favorites'))
 		) {
 			try {
 				$favoriteFilter = $this->activityManager->getFilterById('files_favorites');

--- a/lib/Event/LoadAdditionalScriptsEvent.php
+++ b/lib/Event/LoadAdditionalScriptsEvent.php
@@ -4,6 +4,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Event;
 
 use OCP\EventDispatcher\Event;

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -166,8 +166,8 @@ class FilesHooks {
 			$affectedUsers = array_merge($affectedUsers, $this->getAffectedUsersFromCachedMounts($fileId));
 		}
 
-		[$filteredEmailUsers, $filteredNotificationUsers] =
-			$this->getFileChangeActivitySettings($fileId, array_keys($affectedUsers), $activityType);
+		[$filteredEmailUsers, $filteredNotificationUsers]
+			= $this->getFileChangeActivitySettings($fileId, array_keys($affectedUsers), $activityType);
 
 		foreach ($affectedUsers as $user => $path) {
 			$user = (string)$user;
@@ -301,7 +301,6 @@ class FilesHooks {
 		}
 	}
 
-
 	/**
 	 * Store the move hook events
 	 *
@@ -327,7 +326,6 @@ class FilesHooks {
 
 		$this->moveCase = false;
 	}
-
 
 	/**
 	 * Renaming a file inside the same folder (a/b to a/c)
@@ -1235,7 +1233,6 @@ class FilesHooks {
 		$this->connection->commit();
 	}
 
-
 	/**
 	 * @param int $fileId
 	 *
@@ -1263,7 +1260,6 @@ class FilesHooks {
 			return !in_array($userId, $unrelatedUsers);
 		}, ARRAY_FILTER_USE_KEY);
 	}
-
 
 	/**
 	 * returns an array of users that have confirmed no access to fileId
@@ -1388,7 +1384,6 @@ class FilesHooks {
 				$usersToCheck = array_values(array_unique(array_merge($usersToCheck, $userIds)));
 			}
 		}
-
 
 		// now that we have a list of eventuals filtered users, we confirm they have no access to the file
 		$filteredUsers = [];

--- a/lib/GroupHelper.php
+++ b/lib/GroupHelper.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity;
 
 use OCP\Activity\Exceptions\UnknownActivityException;

--- a/lib/Listener/AddMissingIndicesListener.php
+++ b/lib/Listener/AddMissingIndicesListener.php
@@ -17,7 +17,6 @@ use OCP\EventDispatcher\IEventListener;
  */
 class AddMissingIndicesListener implements IEventListener {
 	#[\Override]
-
 	public function handle(Event $event): void {
 		if (!($event instanceof AddMissingIndicesEvent)) {
 			return;

--- a/lib/Migration/Version2010Date20190416112817.php
+++ b/lib/Migration/Version2010Date20190416112817.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132544.php
+++ b/lib/Migration/Version2011Date20201006132544.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132545.php
+++ b/lib/Migration/Version2011Date20201006132545.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132546.php
+++ b/lib/Migration/Version2011Date20201006132546.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132547.php
+++ b/lib/Migration/Version2011Date20201006132547.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -127,7 +127,6 @@ class Personal implements ISettings {
 		$this->initialState->provideInitialState('methods', $methods);
 		$this->initialState->provideInitialState('activity_digest_enabled', $this->userSettings->getUserSetting($this->userId, 'setting', 'activity_digest'));
 
-
 		return new TemplateResponse('activity', 'settings/personal', [
 			'setting' => 'personal',
 			'activityGroups' => $activityGroups,

--- a/lib/ViewInfoCache.php
+++ b/lib/ViewInfoCache.php
@@ -18,7 +18,6 @@ class ViewInfoCache {
 	/** @var array */
 	protected $cacheId;
 
-
 	public function __construct(
 		protected IRootFolder $rootFolder,
 	) {

--- a/tests/Controller/FeedControllerTest.php
+++ b/tests/Controller/FeedControllerTest.php
@@ -101,7 +101,6 @@ class FeedControllerTest extends TestCase {
 		);
 	}
 
-
 	public function showData(): array {
 		return [
 			['application/rss+xml', 'application/rss+xml'],

--- a/tests/GroupHelperTest.php
+++ b/tests/GroupHelperTest.php
@@ -186,7 +186,6 @@ class GroupHelperTest extends TestCase {
 		$this->assertSame($event, $instance);
 	}
 
-
 	protected function createEvent(array $data): IEvent {
 		/** @var IEvent|MockObject $event */
 		$event = $this->createMock(IEvent::class);

--- a/tests/MailQueueHandlerTest.php
+++ b/tests/MailQueueHandlerTest.php
@@ -99,7 +99,6 @@ class MailQueueHandlerTest extends TestCase {
 	/** @var MockObject|UserSettings */
 	protected UserSettings $userSettings;
 
-
 	protected function setUp(): void {
 		parent::setUp();
 

--- a/tests/stubs/oca_theming_defaults.php
+++ b/tests/stubs/oca_theming_defaults.php
@@ -3,19 +3,19 @@
 namespace OCA\Theming {
 	interface ThemingDefaults {
 		public function getName(): string;
-	
+
 		public function getHTMLName(): string;
 
 		public function getTitle(): string;
-	
+
 		public function getProductName(): string;
-	
+
 		public function getBaseUrl(): string;
 
 		public function getSlogan(?string $lang = null): string;
-	
+
 		public function getImprintUrl(): string;
-	
+
 		public function getPrivacyUrl(): string;
 	}
 }


### PR DESCRIPTION
`php-cs` is currently red on every open PR against this branch — including ones that touch no PHP at all (e.g. #2827, a `package.json` dependency bump). This clears the backlog so unrelated PRs stop inheriting the failure.

## What this is

Purely the output of `composer run cs:fix`. **No behaviour change.** 24 of 94 files, 31 insertions / 26 deletions, and the changes are only:

- blank-line additions/removals, and
- the `operator_linebreak` fixer moving `&&`, `||` and `=` from end-of-line to start-of-the-next-line, e.g.

```php
-		if ($systemConfig->getValue($configPrefix . 'dbuser', null) === null &&
-			$systemConfig->getValue($configPrefix . 'dbhost', null) === null &&
+		if ($systemConfig->getValue($configPrefix . 'dbuser', null) === null
+			&& $systemConfig->getValue($configPrefix . 'dbhost', null) === null
```

Verified `composer run cs:check` afterwards reports `Found 0 of 94 files`, and `php -l` is clean on all 24 changed files.

## Why it drifted

`vendor-bin/cs-fixer/composer.json` requires `friendsofphp/php-cs-fixer: "*"`. The lock currently resolves 3.95.17, whose rules flag code that passed under the previously-locked version — so this is fixer-version drift, not new sloppy code. It passed as recently as #2540 (April).

Worth noting this will recur on each fixer bump while the constraint stays `"*"`. Pinning it, or letting Renovate's `friendsofphp/php-cs-fixer` update through with a `cs:fix` run attached, would stop the churn — happy to follow up separately if wanted.
