### PR TITLE
chore: run composer cs:fix to satisfy php-cs (stable33)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\AppInfo;
 
 use OC\DB\ConnectionAdapter;

--- a/lib/BackgroundJob/EmailNotification.php
+++ b/lib/BackgroundJob/EmailNotification.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\BackgroundJob;
 
 use OCA\Activity\MailQueueHandler;

--- a/lib/BackgroundJob/ExpireActivities.php
+++ b/lib/BackgroundJob/ExpireActivities.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\BackgroundJob;
 
 use OCA\Activity\Data;

--- a/lib/Consumer.php
+++ b/lib/Consumer.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity;
 
 use OCP\Activity\ActivitySettings;

--- a/lib/Controller/APIv2Controller.php
+++ b/lib/Controller/APIv2Controller.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\Data;

--- a/lib/Controller/ActivitiesController.php
+++ b/lib/Controller/ActivitiesController.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\Data;

--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\Data;

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity\Controller;
 
 use OCA\Activity\CurrentUser;

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity;
 
 use Doctrine\DBAL\Platforms\MySQLPlatform;

--- a/lib/Event/LoadAdditionalScriptsEvent.php
+++ b/lib/Event/LoadAdditionalScriptsEvent.php
@@ -4,6 +4,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Event;
 
 use OCP\EventDispatcher\Event;

--- a/lib/FilesHooks.php
+++ b/lib/FilesHooks.php
@@ -301,7 +301,6 @@ class FilesHooks {
 		}
 	}
 
-
 	/**
 	 * Store the move hook events
 	 *
@@ -327,7 +326,6 @@ class FilesHooks {
 
 		$this->moveCase = false;
 	}
-
 
 	/**
 	 * Renaming a file inside the same folder (a/b to a/c)
@@ -1246,7 +1244,6 @@ class FilesHooks {
 		$this->connection->commit();
 	}
 
-
 	/**
 	 * @param int $fileId
 	 *
@@ -1274,7 +1271,6 @@ class FilesHooks {
 			return !in_array($userId, $unrelatedUsers);
 		}, ARRAY_FILTER_USE_KEY);
 	}
-
 
 	/**
 	 * returns an array of users that have confirmed no access to fileId
@@ -1399,7 +1395,6 @@ class FilesHooks {
 				$usersToCheck = array_values(array_unique(array_merge($usersToCheck, $userIds)));
 			}
 		}
-
 
 		// now that we have a list of eventuals filtered users, we confirm they have no access to the file
 		$filteredUsers = [];

--- a/lib/GroupHelper.php
+++ b/lib/GroupHelper.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Activity;
 
 use OCP\Activity\Exceptions\UnknownActivityException;

--- a/lib/Listener/AddMissingIndicesListener.php
+++ b/lib/Listener/AddMissingIndicesListener.php
@@ -17,7 +17,6 @@ use OCP\EventDispatcher\IEventListener;
  */
 class AddMissingIndicesListener implements IEventListener {
 	#[\Override]
-
 	public function handle(Event $event): void {
 		if (!($event instanceof AddMissingIndicesEvent)) {
 			return;

--- a/lib/Migration/Version2010Date20190416112817.php
+++ b/lib/Migration/Version2010Date20190416112817.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132544.php
+++ b/lib/Migration/Version2011Date20201006132544.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132545.php
+++ b/lib/Migration/Version2011Date20201006132545.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132546.php
+++ b/lib/Migration/Version2011Date20201006132546.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Migration/Version2011Date20201006132547.php
+++ b/lib/Migration/Version2011Date20201006132547.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Activity\Migration;
 
 use Closure;

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -127,7 +127,6 @@ class Personal implements ISettings {
 		$this->initialState->provideInitialState('methods', $methods);
 		$this->initialState->provideInitialState('activity_digest_enabled', $this->userSettings->getUserSetting($this->userId, 'setting', 'activity_digest'));
 
-
 		return new TemplateResponse('activity', 'settings/personal', [
 			'setting' => 'personal',
 			'activityGroups' => $activityGroups,

--- a/tests/Controller/FeedControllerTest.php
+++ b/tests/Controller/FeedControllerTest.php
@@ -83,7 +83,6 @@ class FeedControllerTest extends TestCase {
 		);
 	}
 
-
 	public static function showData(): array {
 		return [
 			['application/rss+xml', 'application/rss+xml'],

--- a/tests/CurrentUserTest.php
+++ b/tests/CurrentUserTest.php
@@ -151,7 +151,6 @@ class CurrentUserTest extends TestCase {
 		}
 		[$type, $shareWith] = $share;
 
-
 		$share = $this->createMock(IShare::class);
 		$share->expects($this->once())
 			->method('getShareType')

--- a/tests/GroupHelperTest.php
+++ b/tests/GroupHelperTest.php
@@ -176,7 +176,6 @@ class GroupHelperTest extends TestCase {
 		$this->assertSame($event, $instance);
 	}
 
-
 	protected function createEvent(array $data): IEvent {
 		/** @var IEvent|MockObject $event */
 		$event = $this->createMock(IEvent::class);

--- a/tests/MailQueueHandlerTest.php
+++ b/tests/MailQueueHandlerTest.php
@@ -76,7 +76,6 @@ class MailQueueHandlerTest extends TestCase {
 	protected UserSettings&MockObject $userSettings;
 	protected IEmailValidator&MockObject $emailValidator;
 
-
 	protected function setUp(): void {
 		parent::setUp();
 


### PR DESCRIPTION
Same as #2831, for stable33. `php-cs` is red on open PRs against this branch (e.g. #2758, a `vue` dependency bump that touches no PHP), so this clears it.

## What this is

Purely the output of `composer run cs:fix`. **No behaviour change** — and on this branch the diff is even narrower than stable32's: 23 of 94 files, and **every single changed line is blank**. 16 blank lines added, 11 removed, zero non-blank changes:

```
$ git diff -U0 | grep -E '^[+-]' | grep -v '^[+-][[:space:]]*$'
(no output)
```

Verified `composer run cs:check` afterwards reports `Found 0 of 94 files`, and `php -l` is clean on all 23 changed files.

## Why it drifted

`vendor-bin/cs-fixer/composer.json` requires `friendsofphp/php-cs-fixer: "*"`. The lock resolves 3.95.17, whose blank-line rules flag code that passed under the previously-locked version — fixer-version drift, not new sloppy code.

As on #2831: this recurs on each fixer bump while the constraint is `"*"`.
