### PR TITLE
feat(filters): Support core API to extend focus filter

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -61,6 +61,7 @@
 	<activity>
 		<filters>
 			<filter>OCA\Activity\Filter\AllFilter</filter>
+			<filter>OCA\Activity\Filter\FocusedFilter</filter>
 			<filter>OCA\Activity\Filter\SelfFilter</filter>
 			<filter>OCA\Activity\Filter\ByFilter</filter>
 		</filters>

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -292,7 +292,7 @@ class Data {
 
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
-			->from('activity');
+			->from('activity', 'a');
 
 		$this->applyStreamConditions($query, $userSettings, $user, $filter, $activeFilter, $objectType, $objectId, $search);
 
@@ -362,6 +362,30 @@ class Data {
 		} elseif ($filter === 'filter') {
 			$query->andWhere($query->expr()->eq('object_type', $query->createNamedParameter($objectType)));
 			$query->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)));
+		} elseif ($filter === 'focused') {
+			// Only activity related to files owned by the user
+			$query->leftJoin('a', 'filecache', 'f',
+				$query->expr()->andX(
+					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
+					$query->expr()->eq('a.object_id', 'f.fileid'),
+				));
+			$query->leftJoin('f', 'mounts', 'm',
+				$query->expr()->andX(
+					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
+					$query->expr()->eq('f.storage', 'm.storage_id'),
+				));
+			// Filter out our own activity
+			$query->andWhere($query->expr()->neq('user', $query->createNamedParameter($user)));
+			$query->andWhere(
+				$query->expr()->orX(
+					// Affected object is one of our files
+					$query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')),
+					// There is no affected object, so the activity affects our user directly
+					$query->expr()->eq('object_type', $query->createNamedParameter('')),
+					// Show all sharing related events
+					$query->expr()->eq('app', $query->createNamedParameter('files_sharing')),
+				)
+			);
 		}
 
 		if ($activeFilter instanceof IFilter) {

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -315,7 +315,18 @@ class Data {
 					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
 					$query->expr()->eq('f.storage', 'm.storage_id'),
 				));
-			$query->andWhere($query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')));
+			// Filter out our own activity
+			$query->andWhere($query->expr()->neq('user', $query->createNamedParameter($user)));
+			$query->andWhere(
+				$query->expr()->orX(
+					// Affected object is one of our files
+					$query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')),
+					// There is no affected object, so the activity affects our user directly
+					$query->expr()->eq('object_type', $query->createNamedParameter('')),
+					// Show all sharing related events
+					$query->expr()->eq('app', $query->createNamedParameter('files_sharing')),
+				)
+			);
 		}
 
 		if ($activeFilter instanceof IFilter) {

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -317,16 +317,22 @@ class Data {
 				));
 			// Filter out our own activity
 			$query->andWhere($query->expr()->neq('user', $query->createNamedParameter($user)));
-			$query->andWhere(
-				$query->expr()->orX(
-					// Affected object is one of our files
-					$query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')),
-					// There is no affected object, so the activity affects our user directly
-					$query->expr()->eq('object_type', $query->createNamedParameter('')),
-					// Show all sharing related events
-					$query->expr()->eq('app', $query->createNamedParameter('files_sharing')),
-				)
-			);
+			$conditions = [
+				// Affected object is one of our files
+				$query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')),
+				// There is no affected object, so the activity affects our user directly
+				$query->expr()->eq('object_type', $query->createNamedParameter('')),
+				// Show all sharing related events
+				$query->expr()->eq('app', $query->createNamedParameter('files_sharing')),
+			];
+			$activityFocusedSelectors = $this->activityManager->getActivityFocusedSelectors();
+			foreach ($activityFocusedSelectors as $activityFocusedSelector) {
+				array_push(
+					$conditions,
+					...$activityFocusedSelector->extendQuery($query, $user)
+				);
+			}
+			$query->andWhere($query->expr()->orX(...$conditions));
 		}
 
 		if ($activeFilter instanceof IFilter) {

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -284,7 +284,7 @@ class Data {
 
 		$query = $this->connection->getQueryBuilder();
 		$query->select('*')
-			->from('activity');
+			->from('activity', 'a');
 
 		$query->where($query->expr()->eq('affecteduser', $query->createNamedParameter($user)));
 
@@ -303,6 +303,19 @@ class Data {
 		} elseif ($filter === 'filter') {
 			$query->andWhere($query->expr()->eq('object_type', $query->createNamedParameter($objectType)));
 			$query->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)));
+		} elseif ($filter === 'focused') {
+			// Only activity related to files owned by the user
+			$query->leftJoin('a', 'filecache', 'f',
+				$query->expr()->andX(
+					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
+					$query->expr()->eq('a.object_id', 'f.fileid'),
+				));
+			$query->leftJoin('f', 'mounts', 'm',
+				$query->expr()->andX(
+					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
+					$query->expr()->eq('f.storage', 'm.storage_id'),
+				));
+			$query->andWhere($query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')));
 		}
 
 		if ($activeFilter instanceof IFilter) {

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -376,16 +376,22 @@ class Data {
 				));
 			// Filter out our own activity
 			$query->andWhere($query->expr()->neq('user', $query->createNamedParameter($user)));
-			$query->andWhere(
-				$query->expr()->orX(
-					// Affected object is one of our files
-					$query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')),
-					// There is no affected object, so the activity affects our user directly
-					$query->expr()->eq('object_type', $query->createNamedParameter('')),
-					// Show all sharing related events
-					$query->expr()->eq('app', $query->createNamedParameter('files_sharing')),
-				)
-			);
+			$conditions = [
+				// Affected object is one of our files
+				$query->expr()->eq('m.mount_point', $query->createNamedParameter('/'.$user.'/')),
+				// There is no affected object, so the activity affects our user directly
+				$query->expr()->eq('object_type', $query->createNamedParameter('')),
+				// Show all sharing related events
+				$query->expr()->eq('app', $query->createNamedParameter('files_sharing')),
+			];
+			$activityFocusedSelectors = $this->activityManager->getActivityFocusedSelectors();
+			foreach ($activityFocusedSelectors as $activityFocusedSelector) {
+				array_push(
+					$conditions,
+					...$activityFocusedSelector->extendQuery($query, $user)
+				);
+			}
+			$query->andWhere($query->expr()->orX(...$conditions));
 		}
 
 		if ($activeFilter instanceof IFilter) {

--- a/lib/Filter/FocusedFilter.php
+++ b/lib/Filter/FocusedFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Filter/FocusedFilter.php
+++ b/lib/Filter/FocusedFilter.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Activity\Filter;
+
+use OCP\Activity\IFilter;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class FocusedFilter implements IFilter {
+	public function __construct(
+		protected IL10N $l,
+		protected IURLGenerator $url
+	) {
+	}
+
+	#[\Override]
+	public function getIdentifier(): string {
+		return 'focused';
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l->t('Focused');
+	}
+
+	#[\Override]
+	public function getPriority(): int {
+		return 1;
+	}
+
+	#[\Override]
+	public function getIcon(): string {
+		return $this->url->getAbsoluteURL($this->url->imagePath('activity', 'activity-dark.svg'));
+	}
+
+	/**
+	 * @param string[] $types
+	 * @return string[] An array of allowed apps from which activities should be displayed
+	 */
+	#[\Override]
+	public function filterTypes(array $types): array {
+		return $types;
+	}
+
+	/**
+	 * @return string[] An array of allowed apps from which activities should be displayed
+	 */
+	#[\Override]
+	public function allowedApps(): array {
+		return [];
+	}
+}

--- a/lib/Filter/FocusedFilter.php
+++ b/lib/Filter/FocusedFilter.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Activity\Filter;
+
+use OCP\Activity\IFilter;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+
+class FocusedFilter implements IFilter {
+	public function __construct(
+		protected IL10N $l,
+		protected IURLGenerator $url
+	) {
+	}
+
+	#[\Override]
+	public function getIdentifier(): string {
+		return 'focused';
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l->t('Focused');
+	}
+
+	#[\Override]
+	public function getPriority(): int {
+		return 1;
+	}
+
+	#[\Override]
+	public function getIcon(): string {
+		return $this->url->getAbsoluteURL($this->url->imagePath('activity', 'activity-dark.svg'));
+	}
+
+	/**
+	 * @param string[] $types
+	 * @return string[] An array of allowed apps from which activities should be displayed
+	 */
+	#[\Override]
+	public function filterTypes(array $types): array {
+		return $types;
+	}
+
+	/**
+	 * @return string[] An array of allowed apps from which activities should be displayed
+	 */
+	#[\Override]
+	public function allowedApps(): array {
+		return [];
+	}
+}


### PR DESCRIPTION
This filter shows all activity related to files from your home. More should be added later.

TODO:
- [ ] ~Activity related to files shared to you?~
- [ ] Activity related to files you edited?
- [ ] related to deck card assigned to you?
- [x] related to your calendars? (implemented in https://github.com/nextcloud/server/pull/63026)
- [ ] ~calendar events you are attending?~ (would be too expensive, and might be covered by above)
- [ ] ~when you are the affected user?~
- [ ] Use another icon

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
