### PR TITLE
fix: ignore playwright dev files in release archive

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+/playwright


### PR DESCRIPTION
Update of the nextcloudignore to avoid shipping dev files