### PR TITLE
fix: Fix focused filter performance issues

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\Files\IRootFolder;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
@@ -106,6 +107,7 @@ class Application extends App implements IBootstrap {
 				$c->get('ActivityConnectionAdapter'),
 				$c->get(LoggerInterface::class),
 				$c->get(IConfig::class),
+				$c->get(IRootFolder::class),
 			);
 		});
 

--- a/lib/Data.php
+++ b/lib/Data.php
@@ -17,6 +17,7 @@ use OCP\Activity\IFilter;
 use OCP\Activity\IManager;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -43,6 +44,7 @@ class Data {
 		protected IDBConnection $connection,
 		protected LoggerInterface $logger,
 		protected IConfig $config,
+		protected IRootFolder $rootFolder,
 	) {
 	}
 
@@ -363,23 +365,20 @@ class Data {
 			$query->andWhere($query->expr()->eq('object_type', $query->createNamedParameter($objectType)));
 			$query->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)));
 		} elseif ($filter === 'focused') {
+			// Get home storage id
+			$storageId = $this->rootFolder->getUserFolder($user)->getMountPoint()->getNumericStorageId();
 			// Only activity related to files owned by the user
 			$query->leftJoin('a', 'filecache', 'f',
 				$query->expr()->andX(
 					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
 					$query->expr()->eq('a.object_id', 'f.fileid'),
 				));
-			$query->leftJoin('f', 'mounts', 'm',
-				$query->expr()->andX(
-					$query->expr()->eq('a.object_type', $query->createNamedParameter('files')),
-					$query->expr()->eq('f.storage', 'm.storage_id'),
-				));
 			// Filter out our own activity
 			$query->andWhere($query->expr()->neq('user', $query->createNamedParameter($user)));
 			$query->andWhere(
 				$query->expr()->orX(
 					// Affected object is one of our files
-					$query->expr()->eq('m.mount_point', $query->createNamedParameter('/' . $user . '/')),
+					$query->expr()->eq('f.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)),
 					// There is no affected object, so the activity affects our user directly
 					$query->expr()->eq('object_type', $query->createNamedParameter('')),
 					// Show all sharing related events

--- a/tests/Controller/APIv1ControllerTest.php
+++ b/tests/Controller/APIv1ControllerTest.php
@@ -37,6 +37,7 @@ use OCA\Activity\UserSettings;
 use OCP\Activity\IExtension;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -117,6 +118,7 @@ class APIv1ControllerTest extends TestCase {
 			Server::get(IDBConnection::class),
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(IConfig::class),
+			$this->createMock(IRootFolder::class),
 		);
 
 		$this->deleteUser($data, 'activity-api-user1');
@@ -227,6 +229,7 @@ class APIv1ControllerTest extends TestCase {
 			Server::get(IDBConnection::class),
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(IConfig::class),
+			$this->createMock(IRootFolder::class),
 		);
 
 		$controller = new APIv1Controller(

--- a/tests/DataDeleteActivitiesTest.php
+++ b/tests/DataDeleteActivitiesTest.php
@@ -32,6 +32,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\DB\IPreparedStatement;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Server;
@@ -62,6 +63,7 @@ class DataDeleteActivitiesTest extends TestCase {
 			Server::get(IDBConnection::class),
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(IConfig::class),
+			$this->createMock(IRootFolder::class),
 		);
 	}
 
@@ -154,6 +156,7 @@ class DataDeleteActivitiesTest extends TestCase {
 			Server::get(IDBConnection::class),
 			$this->createMock(LoggerInterface::class),
 			$config,
+			$this->createMock(IRootFolder::class),
 		);
 
 		$time = $this->createMock(ITimeFactory::class);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -30,6 +30,7 @@ use OCA\Activity\UserSettings;
 use OCP\Activity\Exceptions\FilterNotFoundException;
 use OCP\Activity\IManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -52,6 +53,7 @@ class DataTest extends TestCase {
 	protected IManager $realActivityManager;
 	protected NullLogger $logger;
 	protected IConfig&MockObject $config;
+	protected IRootFolder&MockObject $rootFolder;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -63,12 +65,14 @@ class DataTest extends TestCase {
 
 		$activityManager = $this->createMock(IManager::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
 
 		$this->data = new Data(
 			$activityManager,
 			$this->dbConnection,
 			$this->logger,
-			$this->config
+			$this->config,
+			$this->rootFolder,
 		);
 	}
 
@@ -516,7 +520,13 @@ class DataTest extends TestCase {
 		$activityManager->method('getFilterById')
 			->willThrowException(new FilterNotFoundException('all'));
 
-		return new Data($activityManager, $this->dbConnection, $this->logger, $this->config);
+		return new Data(
+			$activityManager,
+			$this->dbConnection,
+			$this->logger,
+			$this->config,
+			$this->rootFolder,
+		);
 	}
 
 	private function getHistogramUserSettings(): UserSettings&MockObject {


### PR DESCRIPTION
There can be several mounts for a same storage id, so the left join on
 oc_mounts was blowing up on a big instance. As we are only intested in
 files from the user’s home, we can compute the storage id beforehand.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
