### PR TITLE
feat(settings): implement IDelegatedSettings for activity admin settings

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -15,9 +15,9 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Settings\ISettings;
+use OCP\Settings\IDelegatedSettings;
 
-class Admin implements ISettings {
+class Admin implements IDelegatedSettings {
 	private IConfig $config;
 	private IL10N $l10n;
 	private IManager $manager;
@@ -116,5 +116,15 @@ class Admin implements ISettings {
 	#[\Override]
 	public function getPriority(): int {
 		return 55;
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return $this->l10n->t('Activity');
+	}
+
+	#[\Override]
+	public function getAuthorizedAppConfig(): array {
+		return [];
 	}
 }


### PR DESCRIPTION
## Summary

Implements `IDelegatedSettings` for the activity admin settings page (`OCA\Activity\Settings\Admin`), instead of the plain `ISettings` interface. This allows an administrator to delegate management of the activity settings to a non-admin user or group via the admin delegation feature, without granting full admin rights.

- `getName()` returns the translated section label, `Activity`.
- `getAuthorizedAppConfig()` returns `[]` — no app config keys are exposed for direct delegated editing beyond the settings form itself.
- `IL10N` is already injected in this class, so the change is additive only.
- `#[\Override]` is set on both new methods, matching the rest of the class.

Companion to https://github.com/nextcloud/bruteforcesettings/pull/1246, which makes the same change for the brute-force IP allowlist settings.

## AI disclosure

This change was prepared with AI assistance (Claude Code): the cherry-pick and rebase mechanics onto current `master`, the `#[\Override]` consistency fix, and this PR description. The underlying code change and the DCO sign-off are from a human contributor.

## Testing

- `composer lint` — clean
- `composer cs:check` — clean, 0 of 98 files need fixing
- `composer psalm` was not run locally: the pinned Psalm 7.0.0-beta19 requires PHP >= 8.3.16 and the available container has PHP 8.3.6. CI covers it here.
- No existing test touches this settings class.
