### PR TITLE
fix(stream): drop deprecated word-break keyword failing stylelint

### DIFF
--- a/src/components/activities/GenericActivity.vue
+++ b/src/components/activities/GenericActivity.vue
@@ -185,7 +185,6 @@ export default defineComponent({
 		flex-grow: 1;
 		overflow-wrap: break-word;
 		white-space: pre-wrap;
-		word-break: break-word;
 		overflow: hidden;
 
 		&__subject {


### PR DESCRIPTION
`npm run stylelint` currently exits 2 on master, so the stylelint job fails on every pull request — it runs on `pull_request` with no path filter. `declaration-property-value-keyword-no-deprecated` reports `word-break: break-word` as an error, not a warning.

The declaration was redundant anyway: the same rule already sets `overflow-wrap: break-word` on the line above, which is what the legacy keyword aliases to. Removing it takes the run to 0 errors, 20 warnings, exit 0.
