### PR TITLE
fix(stream): recover from filter changes, unknown filters and stray polls

### DIFF
--- a/src/__tests__/ActivityAppFeed.test.ts
+++ b/src/__tests__/ActivityAppFeed.test.ts
@@ -65,6 +65,7 @@ vi.mock(import('@vueuse/core'), async (importOriginal) => {
 // Imported after mocks are registered
 import ncAxios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
+import { useRoute } from 'vue-router'
 
 // --- Constants ---
 
@@ -298,6 +299,34 @@ describe('ActivityAppFeed', () => {
 			wrapper.unmount()
 		})
 
+		it('does not start a second polling chain when visibility toggles mid-request', async () => {
+			const wrapper = await mountFeed()
+
+			let resolvePoll: (value: unknown) => void = () => {}
+			vi.mocked(ncAxios.get).mockReturnValueOnce(new Promise((resolve) => {
+				resolvePoll = resolve
+			}))
+			vi.advanceTimersByTime(POLL_INTERVAL)
+			await nextTick()
+
+			// Hiding cannot cancel the request that is already in flight
+			visibilityRef.value = 'hidden'
+			await nextTick()
+			visibilityRef.value = 'visible'
+			await nextTick()
+
+			resolvePoll(makeResponse([], '1'))
+			await flushPromises()
+
+			vi.mocked(ncAxios.get).mockClear()
+			vi.mocked(ncAxios.get).mockResolvedValueOnce(makeResponse([], '1'))
+			vi.advanceTimersByTime(POLL_INTERVAL)
+			await flushPromises()
+
+			expect(vi.mocked(ncAxios.get)).toHaveBeenCalledOnce()
+			wrapper.unmount()
+		})
+
 		it('stops polling when the tab becomes hidden and resumes when visible', async () => {
 			const wrapper = await mountFeed()
 
@@ -401,6 +430,38 @@ describe('ActivityAppFeed', () => {
 			expect(url).not.toContain('from=')
 			expect(url).not.toContain('to=')
 			expect(url).not.toContain('actor=')
+			wrapper.unmount()
+		})
+
+		it('loads the new filter when it changes while a request is still in flight', async () => {
+			// A stuck `loading` flag would swallow the reload, not just delay it
+			vi.mocked(ncAxios.get).mockReturnValueOnce(new Promise(() => {}))
+			const wrapper = mount(ActivityAppFeed, { props: { filter: 'all' }, global: { stubs } })
+			await nextTick()
+
+			vi.mocked(ncAxios.get)
+				.mockResolvedValueOnce(makeResponse())
+				.mockRejectedValueOnce(make304Error())
+			await wrapper.setProps({ filter: 'files' })
+			await flushPromises()
+
+			const urls = vi.mocked(ncAxios.get).mock.calls.map((call) => String(call[0]))
+			expect(urls.some((url) => url.includes('/files?'))).toBe(true)
+			expect(wrapper.findAll('.activity-group').length).toBeGreaterThan(0)
+			wrapper.unmount()
+		})
+
+		it('renders a heading for a filter that is not in the navigation list', async () => {
+			vi.mocked(useRoute).mockReturnValueOnce({
+				params: { filter: 'does-not-exist' },
+				query: routeQuery.current,
+			} as never)
+			vi.mocked(ncAxios.get).mockRejectedValueOnce(make304Error())
+
+			const wrapper = mount(ActivityAppFeed, { props: { filter: 'does-not-exist' }, global: { stubs } })
+			await flushPromises()
+
+			expect(wrapper.find('.activity-app__heading').text()).toBe('All activities')
 			wrapper.unmount()
 		})
 

--- a/src/views/ActivityAppFeed.vue
+++ b/src/views/ActivityAppFeed.vue
@@ -222,6 +222,12 @@ const POLL_INTERVAL = 30000
 let pollTimer: ReturnType<typeof setTimeout> | undefined
 
 /**
+ * Identifies the current polling chain, so one that was superseded while its
+ * request was in flight stops instead of running alongside its replacement.
+ */
+let pollGeneration = 0
+
+/**
  * AbortController for in-flight load and poll requests.
  * Replaced on filter change and aborted on unmount so stale responses
  * are never applied to the wrong filter's state.
@@ -266,7 +272,9 @@ const groupedActivities = computed(() => {
 })
 
 const headingTitle = computed(() => {
-	return navigationList.find((navigationEl) => navigationEl.id === route.params.filter).name
+	// Unknown filters fall back to 'all', matching Data::validateFilter() server-side
+	const match = (id: unknown) => navigationList.find((entry) => entry.id === id)
+	return (match(route.params.filter) ?? match('all'))?.name ?? ''
 })
 
 /**
@@ -357,8 +365,10 @@ async function loadActivities() {
 /**
  * Poll for new activities and either prepend them directly (when near top)
  * or queue them so the user can load them without disrupting their scroll position
+ *
+ * @param generation - Identifier of the polling chain this call belongs to
  */
-async function pollNewActivities() {
+async function pollNewActivities(generation: number) {
 	const { signal } = requestController
 	try {
 		const since = String(newestActivityId.value ?? 0)
@@ -385,9 +395,9 @@ async function pollNewActivities() {
 		}
 	}
 
-	// Self-schedule only if polling wasn't stopped while the request was in flight
-	if (pollTimer !== undefined) {
-		pollTimer = setTimeout(pollNewActivities, POLL_INTERVAL)
+	// Self-schedule only if this chain is still the current one
+	if (generation === pollGeneration) {
+		pollTimer = setTimeout(() => pollNewActivities(generation), POLL_INTERVAL)
 	}
 }
 
@@ -413,19 +423,16 @@ const onScroll = useDebounceFn(() => {
  */
 function startPolling() {
 	stopPolling()
-	// Use a sentinel value so the self-scheduling logic in pollNewActivities
-	// knows polling is active even before the first tick fires
-	pollTimer = setTimeout(pollNewActivities, POLL_INTERVAL)
+	const generation = ++pollGeneration
+	pollTimer = setTimeout(() => pollNewActivities(generation), POLL_INTERVAL)
 }
 
 /**
  *
  */
 function stopPolling() {
-	if (pollTimer !== undefined) {
-		clearTimeout(pollTimer)
-		pollTimer = undefined
-	}
+	pollGeneration++
+	clearTimeout(pollTimer)
 }
 
 /**
@@ -458,6 +465,9 @@ watch(visibility, (value) => {
 function resetAndReload() {
 	requestController.abort()
 	requestController = new AbortController()
+	// The aborted request leaves `loading` set (its `finally` deliberately skips
+	// the reset), so clear it here or the reload below hits the re-entrancy guard
+	loading.value = false
 	allActivities.value = []
 	newActivitiesAvailable.value = false
 	lastActivityLoaded.value = undefined


### PR DESCRIPTION
Three faults in the feed, all reachable from normal use.

**Filter change mid-load wedges the stream.** Two guards cancel each other out. The watcher aborts the in-flight request and calls `loadActivities()` synchronously, but `loading` is still `true` at that point, so the reload hits the re-entrancy guard and returns. The aborted request's `finally` then deliberately skips clearing the flag, assuming the replacement call already set it. Neither happens, and the view sits on "Loading activities" forever.

**Unknown filter kills the view.** `navigationList.find(...).name` had no guard, so any filter not in the navigation list threw out of a computed. Unknown filters now fall back to `all`, matching what `Data::validateFilter()` already does server-side.

**Duplicate polling chains.** `stopPolling()` can't cancel a request already in flight. Hiding and re-showing the tab during one leaves the returning request rescheduling itself alongside its replacement — two requests per interval, compounding with each repeat.

The polling test measures the request count rather than asserting on timers, so it fails on the current code rather than passing vacuously.
