### PR TITLE
fix(stream): stop discarding rich message parameters

### DIFF
--- a/src/__tests__/ActivityModel.test.ts
+++ b/src/__tests__/ActivityModel.test.ts
@@ -1,0 +1,47 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { IRawActivity } from '../models/types.ts'
+
+import { describe, expect, it } from 'vitest'
+import ActivityModel from '../models/ActivityModel.ts'
+
+const mention = { type: 'user', id: 'bob', name: 'Bob' }
+
+/**
+ * Build a raw comment activity carrying the given rich message parameters.
+ *
+ * @param messageParameters - value of `message_rich[1]`
+ */
+function makeActivity(messageParameters: unknown): ActivityModel {
+	return new ActivityModel({
+		activity_id: 1,
+		app: 'comments',
+		type: 'comments',
+		user: 'admin',
+		subject: 'Admin commented',
+		subject_rich: ['', []],
+		message: 'Hello Bob',
+		message_rich: ['Hello {mention-user1}', messageParameters],
+		object_type: 'files',
+		object_id: 1,
+		object_name: '/welcome.md',
+		link: '',
+		icon: 'http://localhost/apps/comments/img/comments.svg',
+		datetime: '2024-01-01T12:00:00+00:00',
+	} as IRawActivity)
+}
+
+// PHP encodes an empty associative array as `[]` and a filled one as an object,
+// so the getter has to normalise the empty-array case to an empty map.
+describe('ActivityModel.messageRichObjects', () => {
+	it('returns the parameters when they are set', () => {
+		expect(makeActivity({ 'mention-user1': mention }).messageRichObjects).toEqual({ 'mention-user1': mention })
+	})
+
+	it('returns an empty map when there are none', () => {
+		expect(makeActivity([]).messageRichObjects).toEqual({})
+	})
+})

--- a/src/models/ActivityModel.ts
+++ b/src/models/ActivityModel.ts
@@ -128,7 +128,7 @@ export default class ActivityModel {
 	 * Get the activity message_rich objects
 	 */
 	get messageRichObjects(): Record<string, IRichObject> {
-		if (!Array.isArray(this._activity.message_rich[1])) {
+		if (Array.isArray(this._activity.message_rich[1])) {
 			return {}
 		}
 


### PR DESCRIPTION
PHP encodes an empty parameter map as `[]` and a filled one as an object, so both getters have to normalise the empty-array case. `subjectRichObjects` does. `messageRichObjects` had the test negated, so it returned an empty map whenever parameters were present, and an array when they were not.

The consumers are `CommentActivity` and `GenericActivity`, so any activity whose message carries rich parameters — a comment with a mention, for instance — rendered its raw `{placeholder}` tokens instead of substituting them.

One character in the fix; the test is the point.
