### PR TITLE
fix(settings): report failures of the admin email toggle

### DIFF
--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -282,14 +282,17 @@ const store = new createStore({
 				},
 			)
 
-			try {
-				OCP.AppConfig.setValue('activity', 'enable_email', emailEnabled ? 'yes' : 'no')
-
-				showSuccess(t('activity', 'Your settings have been updated.'))
-			} catch (error) {
-				showError(t('activity', 'Unable to save the settings'))
-				logger.error('An error occurred while saving the activity settings', { error })
-			}
+			// setValue reports failures through the error callback, never by throwing
+			OCP.AppConfig.setValue('activity', 'enable_email', emailEnabled ? 'yes' : 'no', {
+				success() {
+					showSuccess(t('activity', 'Your settings have been updated.'))
+				},
+				error(error: unknown) {
+					commit('TOGGLE_EMAIL_ENABLED', { emailEnabled: !emailEnabled })
+					showError(t('activity', 'Unable to save the settings'))
+					logger.error('An error occurred while saving the activity settings', { error })
+				},
+			})
 		},
 
 		/**


### PR DESCRIPTION
`OCP.AppConfig.setValue()` dispatches asynchronously and reports failures through its `error` callback, never by throwing, so the `try`/`catch` around it could not fire. The success toast was shown unconditionally and before the request had even completed — including when it failed outright, or when password confirmation was declined.

Now wired to the `success` and `error` callbacks, with the optimistic mutation rolled back when the write doesn't land so the toggle keeps matching the server.
